### PR TITLE
feat(sources): ToolSource abstraction + config-defined tools (no hard-coded tool names)

### DIFF
--- a/docs/concepts/kits.md
+++ b/docs/concepts/kits.md
@@ -59,6 +59,31 @@ svc.toolbox.register_tool(ToolSpec(
 
 The `python` provider is always registered. It resolves tools by importing the named module and looking up the function.
 
+### Tools come from sources (no hard-coded names)
+
+Tools are never hard-coded in lackpy by name — they come from **tool sources** that
+fully define them. The first source is **config-defined**: declare a tool in
+`.lackpy/config.toml` under a top-level `[[tools]]` array and it is loaded at service
+init (no Python needed):
+
+```toml
+[[tools]]
+name = "count_lines"
+provider = "python"
+module = "my_tools"
+function = "count_lines"
+description = "Count the number of lines in a file"
+returns = "int"
+grade_w = 1
+effects_ceiling = 0
+args = [{ name = "path", type = "str", description = "File path" }]
+```
+
+The shipped builtins (`read_file`, `find_files`, `write_file`, `edit_file`) are
+themselves config-defined data (`lackpy/sources/default_tools.toml`), auto-loaded by
+default; a `[[tools]]` entry with the same name overrides one. MCP-discovered and
+virtual/harness sources are planned — see [Tool Sources (RFC 0002)](../design/tool-sources.md).
+
 ---
 
 ## Provider table

--- a/docs/design/tool-sources.md
+++ b/docs/design/tool-sources.md
@@ -1,0 +1,228 @@
+# RFC 0002 — Tool sources (config, MCP, virtual) & the sync↔async bridge
+
+!!! note "Status"
+    Increment 1 (config-defined source) is **implemented**. Increments 2–5
+    (MCP client, multi/host config, virtual tools, kits→profile) are **design-only**
+    here. Siblings: [Direction](direction.md), [Interpreter Types](interpreter-types.md),
+    RFC 0001 (the `lackpy-lang` leaf split).
+
+## 1. Problem & goals
+
+[direction.md](direction.md) calls for retiring "kit" as a primitive and generalizing
+it into a runtime-config system. The **foundational invariant** for that work: *tool
+names are never hard-coded in lackpy source.* Every tool — its full `ToolSpec` and its
+callable — must originate from a **source** that owns it end to end. Before this RFC,
+the invariant was violated by `service._BUILTIN_TOOLS` (a hard-coded spec list) and by
+`.kit` files referencing names that only resolve against code-built specs.
+
+Goals:
+
+1. A single `ToolSource` abstraction implemented by config-defined, MCP-discovered, and
+   virtual/harness tools alike.
+2. Design the deferred sources and cross-cutting concerns: multi-config merge &
+   namespacing, grade-from-hints, security.
+3. Solve the centerpiece: a **synchronous** lackpy program calling an **async** MCP
+   `call_tool` mid-execution — without deadlock.
+
+Non-goals: the kits→profile layer that sits *on top* of sources (sequenced last, §10).
+
+## 2. The ToolSource model
+
+`kit/providers/base.py`'s `ToolProvider` does **resolution only**
+(`name`/`available`/`resolve(spec)->callable`); discovery was hard-coded by the caller.
+The new surface adds **discovery**:
+
+```python
+class ToolSource(Protocol):
+    @property
+    def name(self) -> str: ...
+    def available(self) -> bool: ...
+    def discover(self) -> list[ToolSpec]: ...      # NEW — the source owns its names
+    def resolve(self, spec: ToolSpec) -> Callable[..., Any]: ...
+```
+
+`discover()` is the only addition over `ToolProvider`; `resolve()` keeps its contract.
+`Toolbox.add_source(source)` discovers specs, registers them, and records the source as
+their resolver (`_spec_owner`), so `Toolbox.resolve(name)` dispatches to the owning
+source first and falls back to the legacy provider dispatch for directly-registered
+tools. Later-added source wins on name collision (user config beats shipped defaults).
+
+**Structural home:** `src/lackpy/sources/` (top-level runtime package), *not*
+`kit/providers/` — "kit" is being retired. `lackpy.sources.*` is runtime and may import
+freely from `run/`/`policy/`/`kit/`; it must never be imported by `lackpy.lang`
+(`tests/lang/test_no_upward_deps.py` now lists `sources` in `FORBIDDEN`). The MCP client
+is **not** a candidate for its own PEP 420 dist like `lackpy-lang` — it depends on the
+async runtime/event loop, the opposite of a pure leaf.
+
+### Increment 1 (implemented): config-defined source
+`ConfigToolSource` reads fully-defined tool dicts (spec + `module`/`function`) and
+resolves callables via the existing `PythonProvider`. The former builtins ship as DATA
+in `src/lackpy/sources/default_tools.toml`, auto-loaded at service init — removing the
+hard-coded `_BUILTIN_TOOLS` list. Users add/override tools via a top-level `[[tools]]`
+array in `.lackpy/config.toml`.
+
+## 3. MCP client design (deferred)
+
+lackpy has only an MCP *server* today (`mcp/server.py`, fastmcp). This introduces the
+first MCP *client*.
+
+- **SDK:** the low-level `mcp.ClientSession` (already an optional dep) — explicit
+  session/loop control, which fastmcp's client hides. MCP stays an optional extra;
+  sources report `available() == False` when `mcp` isn't installed.
+- **Transports:** stdio (`command`/`args`/`env`/`cwd`) and streamable-http/SSE
+  (`url`/`headers`).
+- **Own config** — `[mcp_servers.<id>]` (transport + connection + per-tool overrides).
+- **Host configs (multiple)** — `[mcp].host_configs = [...]` paths to host MCP server
+  maps (the `mcp__claude_ai_*` / `mcp__plugin_*` shape). Normalized into the same
+  internal descriptor, tagged with provenance (own / host:<path>) for precedence (§4)
+  and security gating (§8). Virtual/harness-provided tools (§7) are the third origin.
+- **Discovery: eager, bounded.** Generation composes against real tool names, so the
+  inventory must exist before generation — lazy discovery defeats the purpose. Connect
+  each server with a per-server timeout; on failure mark that source unavailable and
+  continue (one dead server must not break others). Eager connect also fixes the cwd
+  hazard (§5.5) by spawning stdio subprocesses before any execution-time `os.chdir`.
+- **Spec build:** MCP `name`→name (after namespacing §4), `description`→description+docs,
+  `inputSchema`→`ArgSpec`s (unknown/nested → `type="Any"`, matching
+  `resolve_python_type`'s fallback), `annotations`→grade (§6).
+
+## 4. Multi-inventory merge, namespacing, precedence (deferred)
+
+Tension: host convention uses long names (`mcp__claude_ai_Gmail__create_draft`), but
+`toolbox._MASKING_NAMES` + the `register_tool` warning exist precisely because long/
+confusing names degrade the small (1.5B) generator lackpy targets.
+
+**Recommendation — short-by-default, qualify-on-collision:** each source contributes
+tools under their bare name; on collision the higher-precedence tool keeps the bare
+name and the loser is *also* kept as `<server>__<tool>`. Names hitting `_MASKING_NAMES`
+auto-qualify + warn (reuse existing machinery).
+
+**Precedence (deterministic), highest wins the bare name:** own `[mcp_servers]` → host
+configs (listed order) → local config-defined/builtins (auditable local source wins).
+Applied once at inventory assembly; the resolved name set feeds `KitPolicySource` and
+`format_description` unchanged.
+
+## 5. The sync↔async bridge (centerpiece, deferred)
+
+lackpy programs run **synchronously** in `run/runner.py` `RestrictedRunner.run` — the
+"lacking" language deliberately has no `await`. MCP `call_tool` is a coroutine, invoked
+mid-program with args known only at runtime.
+
+### 5.1 The deadlock the obvious implementation creates
+Today `service._execute` calls `self._runner.run(...)` **on the event-loop thread**
+(inside async `delegate`). If an MCP callable does
+`asyncio.run_coroutine_threadsafe(call_tool(...), loop).result()` against that same
+loop, it **deadlocks**: the loop is blocked inside the sync runner, so the submitted
+coroutine never runs. Therefore the fix is a **required call-site change**, not merely
+"use a thread":
+
+```python
+async def _execute(self, program, callables, param_values, kibitzer):
+    loop = asyncio.get_running_loop()
+    prev = os.getcwd()
+    def _body():
+        os.chdir(self._workspace)
+        try:
+            return self._runner.run(program, callables, params=param_values,
+                                    kibitzer_session=kibitzer)
+        finally:
+            os.chdir(prev)
+    return await loop.run_in_executor(None, _body)
+```
+
+Offloading the sync runner to a worker thread frees the loop to service marshaled
+coroutines.
+
+### 5.2 The MCP callable
+`source.resolve(spec)` returns a plain sync callable the runner traces like any other;
+it marshals to the loop and blocks the *worker* thread:
+```python
+fut = asyncio.run_coroutine_threadsafe(session.call_tool(mcp_name, kwargs), loop)
+result = fut.result(timeout=timeout)   # FuturesTimeout -> cancel + raise TimeoutError
+# result.isError -> RuntimeError; else unwrap content blocks -> Python value
+```
+
+### 5.3 Session lifecycle
+"One persistent session per server" means you **cannot** `async with` per call. Use a
+long-lived per-server manager coroutine that enters the transport + `ClientSession`
+context once, `initialize()`s, does eager `list_tools()`, then awaits a shutdown event
+to keep the context (and stdio subprocess) alive for `call_tool`.
+
+### 5.4 Which loop hosts the sessions
+- MCP-server path (fastmcp owns a long-lived loop): capture it; sessions persist.
+- CLI path (`asyncio.run` per invocation): lazy session init on the ambient loop,
+  one-shot per invocation. Escalation (documented, not built): a dedicated client loop
+  on its own thread for cross-invocation persistence.
+
+### 5.5 cwd is process-global
+`os.chdir` is process-global, not thread-local — once `_execute` runs in a worker
+thread, concurrent ops race on cwd, and stdio servers spawned during the window inherit
+the wrong cwd. Mitigations: spawn stdio servers eagerly (§3); single-flight execution
+per service instance for now; principled fix is dropping `os.chdir` for an explicit
+workspace root threaded into tool callables.
+
+### 5.6 Errors — already solved
+`run/trace.py` `make_traced` already catches exceptions into a failed `TraceEntry` and
+re-raises into a failed `ExecutionResult`. The MCP callable just translates MCP failures
+(timeout, `isError`) into ordinary Python exceptions — no new trace plumbing.
+
+### 5.7 Rejected
+Nested `asyncio.run`/new loop per call (kills the persistent session, re-`initialize()`
+per call is prohibitive); making the language async (violates lackpy's design).
+
+## 6. Grade from MCP hints (deferred)
+
+Map MCP advisory annotations → `Grade(w, d)` (w = world coupling, d = effects ceiling):
+
+| annotations | (w, d) |
+|---|---|
+| readOnly + closed-world | (1, 0) |
+| readOnly + openWorld | (2, 1) |
+| write + idempotent + non-destructive | (3, 2) |
+| write + (non-idempotent or destructive) | (3, 3) |
+| any relevant hint absent | (3, 3) — conservative |
+
+Invariants (ordering canonical; exact integers the maintainer's call): external coupling
+raises **w**; destructiveness/non-idempotence raises **d**; **config override always
+wins**. Do not mix partial MCP annotation defaults with the mapping — any missing hint
+⇒ conservative. Derived grades land on the `ToolSpec` and feed `compute_grade` →
+`ResolvedKit.grade` → `KitPolicySource` → kibitzer with **zero downstream change**.
+
+## 7. Virtual / harness-provided tools (deferred)
+
+A virtual tool is **fully declared** (`[virtual_tools.<name>]` with full spec) but its
+implementation is supplied by the harness/host at call time and may be absent. The
+harness passes a resolver into the service; `VirtualToolSource.available()`/`resolve()`
+consult it. Enforce at **both** layers: availability gates visibility at generation
+(filtered from `allowed_tools`/`namespace_desc`, so the LLM never composes an absent
+tool), and a call-time `RuntimeError` if it was withdrawn after generation (flows
+through `make_traced` like any failure).
+
+## 8. Security
+
+Three trust tiers, explicit: **config/python** (arbitrary import/exec; trusted because
+auditable local source; highest precedence) > **MCP** (remote, opaque; conservative
+grade; provenance-tracked so a future `McpPolicySource` can gate host-config tools
+tighter) > **virtual** (trust follows the harness). The grade → `KitPolicySource` →
+kibitzer chain is unchanged; new sources plug in by populating grades correctly.
+
+## 9. Open questions
+
+1. Connect-timeout budget for eager discovery across many host servers (parallel connect
+   + global deadline?).
+2. stdio subprocess cwd when host config and lackpy workspace differ.
+3. Runtime tool churn (`list_changed`) — re-discover or fix inventory per lifetime?
+   (Recommend fixed for v1.)
+4. Canonical Python value for MCP content blocks (text→str, structured→dict, multi→list?).
+5. Per-call vs per-session timeout granularity; cancelling a hung call mid-program.
+
+## 10. Migration & sequencing
+
+1. **Config-defined source** — *implemented* (this PR). `_BUILTIN_TOOLS` removed;
+   builtins now data.
+2. **MCP client + bridge** — ships the `run_in_executor` change (§5.1); independently
+   testable (fake async tool: assert no deadlock + correct trace). Own `[mcp_servers]`.
+3. **Multi/host config + namespacing** (§3.4, §4).
+4. **Virtual/harness tools** (§7).
+5. **kits→profile layer** on top of sources, retiring "kit" ([direction.md](direction.md) §2).
+
+Throughout: keep `tests/lang/test_no_upward_deps.py` green.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -77,6 +77,7 @@ nav:
     - LangChain Integration: extending/langchain.md
   - Design:
     - Direction (roadmap): design/direction.md
+    - Tool Sources (RFC 0002): design/tool-sources.md
     - Interpreter Types: design/interpreter-types.md
   - Reference:
     - Python API: reference/api.md

--- a/src/lackpy/config.py
+++ b/src/lackpy/config.py
@@ -26,6 +26,7 @@ class LackpyConfig:
     sandbox_memory_mb: int = 512
     inference_mode: str | None = None
     tool_providers: dict[str, dict[str, Any]] = field(default_factory=dict)
+    tools: list[dict[str, Any]] = field(default_factory=list)
     config_dir: Path = field(default_factory=lambda: Path(".lackpy"))
 
 
@@ -42,6 +43,7 @@ def load_config(workspace: Path | None = None) -> LackpyConfig:
     kit = data.get("kit", {})
     sandbox = data.get("sandbox", {})
     tool_providers = data.get("tool_providers", {})
+    tools = data.get("tools", [])
     providers: dict[str, dict[str, Any]] = {}
     for name, cfg in inference.get("providers", {}).items():
         providers[name] = cfg
@@ -54,5 +56,6 @@ def load_config(workspace: Path | None = None) -> LackpyConfig:
         sandbox_timeout=sandbox.get("timeout_seconds", 120),
         sandbox_memory_mb=sandbox.get("memory_mb", 512),
         tool_providers=tool_providers,
+        tools=tools,
         config_dir=config_dir,
     )

--- a/src/lackpy/kit/providers/builtin.py
+++ b/src/lackpy/kit/providers/builtin.py
@@ -1,10 +1,15 @@
-"""Built-in tool provider — tools implemented inside lackpy."""
+"""Built-in tool provider — tools implemented inside lackpy.
+
+Retained for direct ``register_provider(BuiltinProvider())`` use (notably in tests).
+The implementations themselves live in ``lackpy.sources.builtins`` (the single
+source of truth shared with the shipped ``default_tools.toml``).
+"""
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Any, Callable
 
+from ...sources.builtins import edit_file, find_files, read_file, write_file
 from ..toolbox import ToolSpec
 
 
@@ -18,34 +23,12 @@ class BuiltinProvider:
 
     def resolve(self, tool_spec: ToolSpec) -> Callable[..., Any]:
         implementations = {
-            "read_file": _builtin_read,
-            "find_files": _builtin_glob,
-            "write_file": _builtin_write,
-            "edit_file": _builtin_edit,
+            "read_file": read_file,
+            "find_files": find_files,
+            "write_file": write_file,
+            "edit_file": edit_file,
         }
         fn = implementations.get(tool_spec.name)
         if fn is None:
             raise KeyError(f"No builtin implementation for '{tool_spec.name}'")
         return fn
-
-
-def _builtin_read(path: str) -> str:
-    return Path(path).read_text()
-
-
-def _builtin_glob(pattern: str) -> list[str]:
-    return sorted(str(p) for p in Path(".").glob(pattern))
-
-
-def _builtin_write(path: str, content: str) -> bool:
-    Path(path).write_text(content)
-    return True
-
-
-def _builtin_edit(path: str, old_str: str, new_str: str) -> bool:
-    p = Path(path)
-    text = p.read_text()
-    if old_str not in text:
-        return False
-    p.write_text(text.replace(old_str, new_str, 1))
-    return True

--- a/src/lackpy/kit/toolbox.py
+++ b/src/lackpy/kit/toolbox.py
@@ -75,6 +75,27 @@ class Toolbox:
     def __init__(self) -> None:
         self.tools: dict[str, ToolSpec] = {}
         self._providers: dict[str, Any] = {}
+        # Per-tool resolver when a tool was contributed by a ToolSource
+        # (the source resolves its own callables; takes precedence over the
+        # name→provider dispatch used by directly-registered tools).
+        self._spec_owner: dict[str, Any] = {}
+
+    def add_source(self, source: Any) -> None:
+        """Discover and register every tool a :class:`ToolSource` provides.
+
+        The source owns resolution for the tools it contributes. A later source
+        overrides an earlier one on name collision (so user config beats shipped
+        defaults). No-op if the source reports itself unavailable.
+
+        Args:
+            source: An object with ``available()``, ``discover()`` and
+                ``resolve(spec)`` (the ToolSource protocol).
+        """
+        if not source.available():
+            return
+        for spec in source.discover():
+            self.register_tool(spec)          # clears any prior owner for this name
+            self._spec_owner[spec.name] = source  # this source now owns resolution
 
     def register_provider(self, provider: Any) -> None:
         """Register a tool provider plugin and load its tools into the registry.
@@ -104,6 +125,9 @@ class Toolbox:
                 UserWarning,
                 stacklevel=2,
             )
+        # A directly-registered tool resolves via provider dispatch; drop any
+        # prior source ownership for this name so a later register_tool wins.
+        self._spec_owner.pop(spec.name, None)
         self.tools[spec.name] = spec
 
     def resolve(self, name: str) -> Callable[..., Any]:
@@ -121,6 +145,9 @@ class Toolbox:
         if name not in self.tools:
             raise KeyError(f"Unknown tool: {name}")
         spec = self.tools[name]
+        owner = self._spec_owner.get(name)
+        if owner is not None:
+            return owner.resolve(spec)
         provider = self._providers.get(spec.provider)
         if provider is None:
             raise KeyError(f"No provider '{spec.provider}' registered for tool '{name}'")

--- a/src/lackpy/service.py
+++ b/src/lackpy/service.py
@@ -15,37 +15,10 @@ from .infer.providers.templates import TemplatesProvider
 from .kit.providers.builtin import BuiltinProvider
 from .kit.providers.python import PythonProvider
 from .kit.registry import ResolvedKit, resolve_kit
-from .kit.toolbox import ArgSpec, Toolbox, ToolSpec
+from .kit.toolbox import Toolbox
 from .lang.grammar import ALLOWED_BUILTINS
 from .policy.layer import PolicyLayer
 from .policy.sources.kit import KitPolicySource
-
-_BUILTIN_TOOLS = [
-    ToolSpec(
-        name="read_file", provider="builtin", description="Read file contents",
-        args=[ArgSpec(name="path", type="str", description="File path")],
-        returns="str", grade_w=1, effects_ceiling=1,
-        docs="docs/tools/read_file.md",
-    ),
-    ToolSpec(
-        name="find_files", provider="builtin", description="Find files matching a glob pattern",
-        args=[ArgSpec(name="pattern", type="str", description="Glob pattern")],
-        returns="list[str]", grade_w=1, effects_ceiling=1,
-        docs="docs/tools/find_files.md",
-    ),
-    ToolSpec(
-        name="write_file", provider="builtin", description="Write content to a file",
-        args=[ArgSpec(name="path", type="str"), ArgSpec(name="content", type="str")],
-        returns="bool", grade_w=3, effects_ceiling=3,
-        docs="docs/tools/write_file.md",
-    ),
-    ToolSpec(
-        name="edit_file", provider="builtin", description="Replace text in a file",
-        args=[ArgSpec(name="path", type="str"), ArgSpec(name="old_str", type="str"), ArgSpec(name="new_str", type="str")],
-        returns="bool", grade_w=3, effects_ceiling=3,
-        docs="docs/tools/edit_file.md",
-    ),
-]
 from .lang.validator import ValidationResult, validate
 from .run.base import ExecutionResult
 from .run.runner import RestrictedRunner
@@ -106,16 +79,37 @@ class LackpyService:
         self._config = config or load_config(self._workspace)
         self._runner = RestrictedRunner()
         self.toolbox = Toolbox()
+        # Resolution mechanisms for directly-registered specs (tools themselves
+        # come from sources, not these). Kept for back-compat with callers that
+        # register their own provider="builtin"/"python" specs.
         self.toolbox.register_provider(BuiltinProvider())
         self.toolbox.register_provider(PythonProvider())
-        for spec in _BUILTIN_TOOLS:
-            self.toolbox.register_tool(spec)
+        for source in self._build_tool_sources():
+            self.toolbox.add_source(source)
         self._inference_providers: list = []
         self._init_inference_providers()
         self._policy = PolicyLayer()
         self._policy.add_source(KitPolicySource(self.toolbox))
         self._kibitzer: Any = None
         self._init_kibitzer()
+
+    def _build_tool_sources(self) -> list[Any]:
+        """Assemble the tool sources that populate the toolbox.
+
+        Shipped defaults first, then user-configured ``[[tools]]`` (so a user
+        definition overrides a default of the same name). Future MCP-discovered
+        and virtual/harness sources slot into this list (see
+        docs/design/tool-sources.md).
+        """
+        from .sources import load_default_tool_defs
+        from .sources.config import ConfigToolSource
+
+        sources: list[Any] = [
+            ConfigToolSource(load_default_tool_defs(), name="default"),
+        ]
+        if self._config.tools:
+            sources.append(ConfigToolSource(self._config.tools, name="config"))
+        return sources
 
     def _init_inference_providers(self) -> None:
         templates_dir = self._config.config_dir / "templates"

--- a/src/lackpy/sources/__init__.py
+++ b/src/lackpy/sources/__init__.py
@@ -1,0 +1,26 @@
+"""Tool sources: where fully-defined tools come from.
+
+A *source* owns BOTH discovery (producing a complete ``ToolSpec`` — name, args,
+returns, docs, grade) AND resolution (producing the callable). This is the seam
+that keeps tool names from being hard-coded in lackpy source: every tool a kit can
+reference originates from a source. The first concrete source is
+``ConfigToolSource`` (config-defined tools); MCP-discovered and virtual/harness
+sources implement the same protocol later (see docs/design/tool-sources.md).
+"""
+
+from __future__ import annotations
+
+import tomllib
+from importlib.resources import files
+from typing import Any
+
+
+def load_default_tool_defs() -> list[dict[str, Any]]:
+    """Load the shipped default tool definitions (formerly hard-coded builtins).
+
+    These ship as data (``default_tools.toml``) rather than Python so the default
+    toolbox contains zero hard-coded ``ToolSpec`` lists. User ``[[tools]]`` entries
+    in ``.lackpy/config.toml`` override these by name.
+    """
+    raw = (files(__package__) / "default_tools.toml").read_text(encoding="utf-8")
+    return tomllib.loads(raw).get("tools", [])

--- a/src/lackpy/sources/base.py
+++ b/src/lackpy/sources/base.py
@@ -1,0 +1,30 @@
+"""The ToolSource protocol.
+
+A ``ToolSource`` is a superset of the resolution-only ``ToolProvider``
+(``kit/providers/base.py``): it adds ``discover()``, so the source — not bare
+lackpy code — owns the set of tool names and their full specs.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Protocol, runtime_checkable
+
+from ..kit.toolbox import ToolSpec
+
+
+@runtime_checkable
+class ToolSource(Protocol):
+    @property
+    def name(self) -> str: ...
+
+    def available(self) -> bool:
+        """Whether this source can currently contribute tools."""
+        ...
+
+    def discover(self) -> list[ToolSpec]:
+        """Return the full specs for every tool this source provides."""
+        ...
+
+    def resolve(self, spec: ToolSpec) -> Callable[..., Any]:
+        """Return the callable implementation for one of this source's specs."""
+        ...

--- a/src/lackpy/sources/builtins.py
+++ b/src/lackpy/sources/builtins.py
@@ -1,0 +1,33 @@
+"""Built-in tool implementations.
+
+These are referenced as data by the shipped ``default_tools.toml`` (via the python
+provider's ``module``/``function`` resolution), not registered by hard-coded
+``ToolSpec`` lists. Paths are relative to the execution cwd (the runner chdirs into
+the workspace before execution).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def read_file(path: str) -> str:
+    return Path(path).read_text()
+
+
+def find_files(pattern: str) -> list[str]:
+    return sorted(str(p) for p in Path(".").glob(pattern))
+
+
+def write_file(path: str, content: str) -> bool:
+    Path(path).write_text(content)
+    return True
+
+
+def edit_file(path: str, old_str: str, new_str: str) -> bool:
+    p = Path(path)
+    text = p.read_text()
+    if old_str not in text:
+        return False
+    p.write_text(text.replace(old_str, new_str, 1))
+    return True

--- a/src/lackpy/sources/config.py
+++ b/src/lackpy/sources/config.py
@@ -1,0 +1,79 @@
+"""Config-defined tool source.
+
+Tools are *fully defined* in configuration — each entry carries its own spec
+(name, args, returns, grade, docs) AND how to resolve its callable (provider +
+module/function). Nothing is hard-coded in lackpy source.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Callable
+
+from ..kit.providers.python import PythonProvider
+from ..kit.toolbox import ArgSpec, ToolSpec
+
+
+class ConfigToolSource:
+    """A :class:`~lackpy.sources.base.ToolSource` backed by config dicts.
+
+    Args:
+        tool_defs: A list of fully-defined tool dicts (see ``default_tools.toml``
+            for the shape). Each needs at least ``name``; ``provider`` defaults to
+            ``"python"`` and resolves via ``module``/``function``.
+        name: The source's name (used as provenance / for diagnostics).
+    """
+
+    def __init__(self, tool_defs: list[dict[str, Any]] | None, name: str = "config") -> None:
+        self._name = name
+        self._tool_defs = tool_defs or []
+        self._python = PythonProvider()
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def available(self) -> bool:
+        return bool(self._tool_defs)
+
+    def discover(self) -> list[ToolSpec]:
+        return [self._spec_from_dict(d) for d in self._tool_defs]
+
+    def resolve(self, spec: ToolSpec) -> Callable[..., Any]:
+        if spec.provider == "python":
+            return self._python.resolve(spec)
+        raise ValueError(
+            f"ConfigToolSource cannot resolve provider {spec.provider!r} for tool "
+            f"{spec.name!r} (supported: 'python')"
+        )
+
+    @staticmethod
+    def _spec_from_dict(d: dict[str, Any]) -> ToolSpec:
+        name = d.get("name")
+        if not name:
+            raise ValueError(f"Tool definition missing 'name': {d!r}")
+        # Fold module/function into provider_config so PythonProvider resolves it.
+        provider_config = dict(d.get("provider_config", {}))
+        if "module" in d:
+            provider_config.setdefault("module", d["module"])
+        if "function" in d:
+            provider_config.setdefault("function", d["function"])
+        args = [
+            ArgSpec(
+                name=a["name"],
+                type=a.get("type", "Any"),
+                description=a.get("description", ""),
+            )
+            for a in d.get("args", [])
+        ]
+        return ToolSpec(
+            name=name,
+            provider=d.get("provider", "python"),
+            provider_config=provider_config,
+            description=d.get("description", ""),
+            args=args,
+            returns=d.get("returns", "Any"),
+            grade_w=d.get("grade_w", 3),
+            effects_ceiling=d.get("effects_ceiling", 3),
+            examples=d.get("examples", []),
+            docs=d.get("docs"),
+        )

--- a/src/lackpy/sources/default_tools.toml
+++ b/src/lackpy/sources/default_tools.toml
@@ -1,0 +1,61 @@
+# Shipped default tools (formerly the hard-coded service._BUILTIN_TOOLS).
+#
+# These are DATA, auto-loaded by ConfigToolSource at service init — not a
+# hard-coded ToolSpec list in Python. A user's .lackpy/config.toml [[tools]]
+# entry with the same name overrides the default; deleting from a local override
+# config is the path toward shipping these as separate addon packages instead.
+
+[[tools]]
+name = "read_file"
+provider = "python"
+module = "lackpy.sources.builtins"
+function = "read_file"
+description = "Read file contents"
+returns = "str"
+grade_w = 1
+effects_ceiling = 1
+docs = "docs/tools/read_file.md"
+args = [{ name = "path", type = "str", description = "File path" }]
+
+[[tools]]
+name = "find_files"
+provider = "python"
+module = "lackpy.sources.builtins"
+function = "find_files"
+description = "Find files matching a glob pattern"
+returns = "list[str]"
+grade_w = 1
+effects_ceiling = 1
+docs = "docs/tools/find_files.md"
+args = [{ name = "pattern", type = "str", description = "Glob pattern" }]
+
+[[tools]]
+name = "write_file"
+provider = "python"
+module = "lackpy.sources.builtins"
+function = "write_file"
+description = "Write content to a file"
+returns = "bool"
+grade_w = 3
+effects_ceiling = 3
+docs = "docs/tools/write_file.md"
+args = [
+    { name = "path", type = "str" },
+    { name = "content", type = "str" },
+]
+
+[[tools]]
+name = "edit_file"
+provider = "python"
+module = "lackpy.sources.builtins"
+function = "edit_file"
+description = "Replace text in a file"
+returns = "bool"
+grade_w = 3
+effects_ceiling = 3
+docs = "docs/tools/edit_file.md"
+args = [
+    { name = "path", type = "str" },
+    { name = "old_str", type = "str" },
+    { name = "new_str", type = "str" },
+]

--- a/tests/lang/test_no_upward_deps.py
+++ b/tests/lang/test_no_upward_deps.py
@@ -13,7 +13,7 @@ import lackpy.lang
 
 LANG_DIR = Path(lackpy.lang.__file__).parent
 FORBIDDEN = {"run", "kit", "policy", "infer", "service", "lackey", "prompts",
-             "interpreters", "mcp"}
+             "interpreters", "mcp", "sources"}
 
 
 def _imported_modules(py: Path):

--- a/tests/sources/test_config_source.py
+++ b/tests/sources/test_config_source.py
@@ -1,0 +1,80 @@
+"""Config-defined tool source: discovery, resolution, grade, override, guard."""
+
+import pytest
+
+from lackpy.kit.toolbox import Toolbox
+from lackpy.sources.config import ConfigToolSource
+
+DEFS = [
+    {
+        "name": "myread",
+        "provider": "python",
+        "module": "lackpy.sources.builtins",
+        "function": "read_file",
+        "description": "read a file",
+        "returns": "str",
+        "grade_w": 1,
+        "effects_ceiling": 1,
+        "args": [{"name": "path", "type": "str", "description": "path"}],
+    }
+]
+
+
+def test_discover_builds_full_spec():
+    spec = ConfigToolSource(DEFS).discover()[0]
+    assert spec.name == "myread"
+    assert spec.grade_w == 1 and spec.effects_ceiling == 1
+    assert [a.name for a in spec.args] == ["path"]
+    assert spec.provider_config == {
+        "module": "lackpy.sources.builtins",
+        "function": "read_file",
+    }
+
+
+def test_available_reflects_defs():
+    assert ConfigToolSource([]).available() is False
+    assert ConfigToolSource(DEFS).available() is True
+
+
+def test_grade_defaults_conservative():
+    spec = ConfigToolSource(
+        [{"name": "x", "module": "lackpy.sources.builtins", "function": "read_file"}]
+    ).discover()[0]
+    assert spec.grade_w == 3 and spec.effects_ceiling == 3
+
+
+def test_missing_name_raises():
+    with pytest.raises(ValueError):
+        ConfigToolSource([{"module": "m", "function": "f"}]).discover()
+
+
+def test_resolve_returns_working_callable(tmp_path):
+    src = ConfigToolSource(DEFS)
+    fn = src.resolve(src.discover()[0])
+    p = tmp_path / "f.txt"
+    p.write_text("hi")
+    assert fn(str(p)) == "hi"
+
+
+def test_toolbox_add_source_then_resolve(tmp_path):
+    tb = Toolbox()
+    tb.add_source(ConfigToolSource(DEFS))
+    assert "myread" in tb.tools
+    p = tmp_path / "f.txt"
+    p.write_text("yo")
+    assert tb.resolve("myread")(str(p)) == "yo"
+
+
+def test_later_source_overrides_earlier():
+    tb = Toolbox()
+    tb.add_source(
+        ConfigToolSource(
+            [{"name": "t", "module": "lackpy.sources.builtins", "function": "read_file"}]
+        )
+    )
+    tb.add_source(
+        ConfigToolSource(
+            [{"name": "t", "module": "lackpy.sources.builtins", "function": "find_files"}]
+        )
+    )
+    assert tb.resolve("t").__name__ == "find_files"

--- a/tests/sources/test_default_tools.py
+++ b/tests/sources/test_default_tools.py
@@ -1,0 +1,79 @@
+"""Shipped default tools: load as data, populate the service, override, no hardcode."""
+
+import lackpy.service as service_module
+from lackpy.config import LackpyConfig
+from lackpy.service import LackpyService
+from lackpy.sources import load_default_tool_defs
+
+
+def test_no_hardcoded_builtin_tools_list():
+    # The whole point of the slice: tools come from sources, not a Python list.
+    assert not hasattr(service_module, "_BUILTIN_TOOLS")
+
+
+def test_default_defs_load_from_packaged_toml():
+    names = {d["name"] for d in load_default_tool_defs()}
+    assert {"read_file", "find_files", "write_file", "edit_file"} <= names
+
+
+def test_service_has_builtins_by_default(tmp_path):
+    svc = LackpyService(workspace=tmp_path)
+    names = {t["name"] for t in svc.toolbox_list()}
+    assert {"read_file", "find_files", "write_file", "edit_file"} <= names
+    # builtins are sourced as data from lackpy.sources.builtins
+    assert svc.toolbox.resolve("read_file").__module__ == "lackpy.sources.builtins"
+
+
+async def test_default_read_file_runs_end_to_end(tmp_path):
+    (tmp_path / "hello.txt").write_text("world")
+    svc = LackpyService(workspace=tmp_path)
+    res = await svc.run_program("content = read_file('hello.txt')\ncontent", kit=["read_file"])
+    assert res.success
+    assert res.output == "world"
+
+
+def test_load_config_parses_user_tools_and_service_picks_them_up(tmp_path):
+    # Exercises config.load_config's [[tools]] parse (not bypassed via LackpyConfig)
+    # and the service auto-loading it from a real .lackpy/config.toml.
+    from lackpy.config import load_config
+
+    cfgdir = tmp_path / ".lackpy"
+    cfgdir.mkdir()
+    (cfgdir / "config.toml").write_text(
+        '[[tools]]\n'
+        'name = "list_glob"\n'
+        'provider = "python"\n'
+        'module = "lackpy.sources.builtins"\n'
+        'function = "find_files"\n'
+        'returns = "list[str]"\n'
+        'grade_w = 1\n'
+        'effects_ceiling = 1\n'
+        'args = [{ name = "pattern", type = "str" }]\n'
+    )
+    cfg = load_config(tmp_path)
+    assert any(t["name"] == "list_glob" for t in cfg.tools)
+
+    svc = LackpyService(workspace=tmp_path)
+    names = {t["name"] for t in svc.toolbox_list()}
+    assert "list_glob" in names
+    assert svc.toolbox.resolve("list_glob").__name__ == "find_files"
+
+
+def test_user_tool_overrides_default(tmp_path):
+    # A user [[tools]] entry with a default's name wins (source order: default then config).
+    cfg = LackpyConfig(
+        tools=[
+            {
+                "name": "read_file",
+                "provider": "python",
+                "module": "lackpy.sources.builtins",
+                "function": "find_files",
+                "returns": "list[str]",
+                "grade_w": 1,
+                "effects_ceiling": 1,
+                "args": [{"name": "path", "type": "str"}],
+            }
+        ]
+    )
+    svc = LackpyService(workspace=tmp_path, config=cfg)
+    assert svc.toolbox.resolve("read_file").__name__ == "find_files"


### PR DESCRIPTION
Foundational step toward generalizing kits into runtime config: **tool names must never be hard-coded.** Tools may only come from a *source* that fully defines them.

## What's in this PR (increment 1 of the RFC)
- **`src/lackpy/sources/`** — `ToolSource` protocol (superset of `ToolProvider`, adds `discover()`); `ConfigToolSource` (dict→`ToolSpec`, resolves via `PythonProvider`); `builtins.py` (single source of truth for the 4 builtin fns); `default_tools.toml` — the former hard-coded `_BUILTIN_TOOLS`, now shipped **data**, auto-loaded.
- **`Toolbox.add_source()`** + per-tool `_spec_owner` resolution; a later source wins on name collision, so user `[[tools]]` override shipped defaults. `register_tool` clears stale ownership.
- **`config.py`** parses a top-level `[[tools]]` array. **`service.py`** builds sources instead of the deleted `_BUILTIN_TOOLS` list (keeps `BuiltinProvider`/`PythonProvider` registered as resolvers for back-compat).
- **`docs/design/tool-sources.md` (RFC 0002)** — full deferred design: MCP client, multi/host config, virtual tools, the sync↔async bridge (incl. the `run_in_executor` deadlock fix), grade-from-MCP-hints. Sequenced as increments 2–5.

## Verification
- 892 tests pass (12 new in `tests/sources/`); leaf-guard extended with `sources`.
- Installed-wheel loads `default_tools.toml` from site-packages (PEP 420 namespace + `importlib.resources` confirmed).
- `load_config` `[[tools]]` parse tested end-to-end; CLI `delegate read_file` runs with the correct grade.

## Not in scope (designed in RFC, future increments)
MCP client/bridge, multi/host config, virtual tools, grade-from-hints, kits→profile layer, pluckit/mock spec migration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)