### PR TITLE
feat: async execution bridge + MCP-discovered tool source (RFC 0002 increment 2)

### DIFF
--- a/docs/concepts/kits.md
+++ b/docs/concepts/kits.md
@@ -81,8 +81,32 @@ args = [{ name = "path", type = "str", description = "File path" }]
 
 The shipped builtins (`read_file`, `find_files`, `write_file`, `edit_file`) are
 themselves config-defined data (`lackpy/sources/default_tools.toml`), auto-loaded by
-default; a `[[tools]]` entry with the same name overrides one. MCP-discovered and
-virtual/harness sources are planned — see [Tool Sources (RFC 0002)](../design/tool-sources.md).
+default; a `[[tools]]` entry with the same name overrides one.
+
+### MCP-discovered tools
+
+With the optional `mcp` extra (`pip install lackpy[mcp]`), lackpy can connect to an
+MCP server as a client and expose its tools — full specs (params from the tool's
+input schema, docs from its description) and a security grade derived from the
+tool's MCP annotations (`readOnlyHint`/`destructiveHint`/…, conservative when
+absent). Declare servers under `[mcp_servers]`:
+
+```toml
+[mcp_servers.fs]
+transport = "stdio"          # or "http" with url = "..."
+command = "mcp-server-filesystem"
+args = ["--root", "."]
+
+# optional per-tool grade override
+[mcp_servers.fs.tools.read_file]
+grade = { w = 1, d = 0 }
+```
+
+MCP I/O runs on a dedicated client loop; an MCP-backed tool call from a (synchronous)
+lackpy program is bridged to that loop without blocking generation. A server that
+fails to connect is skipped (its tools simply don't appear), never breaking the
+others. Multi-server namespacing, host-config ingestion, and virtual/harness tools
+are planned — see [Tool Sources (RFC 0002)](../design/tool-sources.md).
 
 ---
 

--- a/docs/design/tool-sources.md
+++ b/docs/design/tool-sources.md
@@ -1,10 +1,11 @@
 # RFC 0002 — Tool sources (config, MCP, virtual) & the sync↔async bridge
 
 !!! note "Status"
-    Increment 1 (config-defined source) is **implemented**. Increments 2–5
-    (MCP client, multi/host config, virtual tools, kits→profile) are **design-only**
-    here. Siblings: [Direction](direction.md), [Interpreter Types](interpreter-types.md),
-    RFC 0001 (the `lackpy-lang` leaf split).
+    Increment 1 (config-defined source) and increment 2 (async bridge + MCP client
+    for own `[mcp_servers]`) are **implemented**. Increments 3–5 (multi/host config
+    + namespacing, virtual tools, kits→profile) are **design-only** here. Siblings:
+    [Direction](direction.md), [Interpreter Types](interpreter-types.md), RFC 0001
+    (the `lackpy-lang` leaf split).
 
 ## 1. Problem & goals
 
@@ -160,6 +161,13 @@ the wrong cwd. Mitigations: spawn stdio servers eagerly (§3); single-flight exe
 per service instance for now; principled fix is dropping `os.chdir` for an explicit
 workspace root threaded into tool callables.
 
+**Implemented tradeoff:** the single-flight guard is a per-service `asyncio.Lock`
+held across *all* of `_execute` — including the pure-inline (no-async-tool) path. So
+a slow MCP-backed delegation serializes even non-MCP delegations on the same service.
+This is deliberate (it reproduces today's cwd-safety) but is a real throughput
+serialization in a long-lived MCP-server host; lifting it depends on the `os.chdir`
+removal above.
+
 ### 5.6 Errors — already solved
 `run/trace.py` `make_traced` already catches exceptions into a failed `TraceEntry` and
 re-raises into a failed `ExecutionResult`. The MCP callable just translates MCP failures
@@ -219,9 +227,12 @@ kibitzer chain is unchanged; new sources plug in by populating grades correctly.
 
 1. **Config-defined source** — *implemented* (this PR). `_BUILTIN_TOOLS` removed;
    builtins now data.
-2. **MCP client + bridge** — ships the `run_in_executor` change (§5.1); independently
-   testable (fake async tool: assert no deadlock + correct trace). Own `[mcp_servers]`.
-3. **Multi/host config + namespacing** (§3.4, §4).
+2. **MCP client + bridge** — *implemented*. 2a: `AsyncBridge` + async `_execute`
+   with the single-flight `asyncio.Lock` and lazy threaded path (`run/bridge.py`).
+   2b: dedicated-loop `McpClient` (loop-ownership decision = dedicated client
+   thread, so eager discovery + session reuse compose across the MCP-server and
+   per-command CLI contexts), `McpToolSource`, grade-from-hints; own `[mcp_servers]`.
+3. **Multi/host config + namespacing** (§3.4, §4) — *next*.
 4. **Virtual/harness tools** (§7).
 5. **kits→profile layer** on top of sources, retiring "kit" ([direction.md](direction.md) §2).
 

--- a/src/lackpy/config.py
+++ b/src/lackpy/config.py
@@ -27,6 +27,7 @@ class LackpyConfig:
     inference_mode: str | None = None
     tool_providers: dict[str, dict[str, Any]] = field(default_factory=dict)
     tools: list[dict[str, Any]] = field(default_factory=list)
+    mcp_servers: dict[str, dict[str, Any]] = field(default_factory=dict)
     config_dir: Path = field(default_factory=lambda: Path(".lackpy"))
 
 
@@ -44,6 +45,7 @@ def load_config(workspace: Path | None = None) -> LackpyConfig:
     sandbox = data.get("sandbox", {})
     tool_providers = data.get("tool_providers", {})
     tools = data.get("tools", [])
+    mcp_servers = data.get("mcp_servers", {})
     providers: dict[str, dict[str, Any]] = {}
     for name, cfg in inference.get("providers", {}).items():
         providers[name] = cfg
@@ -57,5 +59,6 @@ def load_config(workspace: Path | None = None) -> LackpyConfig:
         sandbox_memory_mb=sandbox.get("memory_mb", 512),
         tool_providers=tool_providers,
         tools=tools,
+        mcp_servers=mcp_servers,
         config_dir=config_dir,
     )

--- a/src/lackpy/run/bridge.py
+++ b/src/lackpy/run/bridge.py
@@ -1,0 +1,65 @@
+"""Sync↔async bridge for tool callables.
+
+lackpy programs execute **synchronously** in :class:`RestrictedRunner` (the
+"lacking" language has no ``await``). Some tool callables — notably MCP-backed
+ones — are async. The bridge lets a sync tool callable, running on a worker
+thread, invoke a coroutine on the service's event loop and block for its result.
+
+Correctness depends on two things the service arranges:
+
+1. The sync runner runs **off** the loop thread (``loop.run_in_executor``), so the
+   loop is free to service the marshaled coroutine. Marshaling onto the same loop
+   the runner blocks would deadlock.
+2. Executions are **single-flight** (an ``asyncio.Lock`` in the service), so only
+   one execution owns the bridge's ``loop`` at a time.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from concurrent.futures import TimeoutError as FuturesTimeout
+from typing import Any, Awaitable
+
+
+class AsyncBridge:
+    """Marshals coroutines from a worker thread onto a target event loop.
+
+    ``loop`` is set by the service for the duration of one execution and cleared
+    afterwards (under the execution lock, so it is never ambiguous).
+    """
+
+    def __init__(self) -> None:
+        self.loop: asyncio.AbstractEventLoop | None = None
+
+    def call_sync(self, coro: Awaitable[Any], timeout: float | None = None) -> Any:
+        """Run ``coro`` on the bridge's loop and block until it returns.
+
+        Intended to be called from a worker thread (never the loop thread).
+
+        Raises:
+            RuntimeError: If no loop is active (called outside an execution).
+            TimeoutError: If the coroutine does not complete within ``timeout``.
+        """
+        loop = self.loop
+        if loop is None:
+            raise RuntimeError(
+                "AsyncBridge has no active loop; an async tool was called outside "
+                "a bridged execution."
+            )
+        fut = asyncio.run_coroutine_threadsafe(coro, loop)
+        try:
+            return fut.result(timeout)
+        except FuturesTimeout:
+            fut.cancel()
+            raise TimeoutError(f"async tool call timed out after {timeout}s")
+
+
+def mark_async(fn: Any) -> Any:
+    """Flag a callable as loop-bound so the service uses the threaded exec path."""
+    fn._lackpy_async = True
+    return fn
+
+
+def is_async_callable(fn: Any) -> bool:
+    """Whether ``fn`` was flagged via :func:`mark_async`."""
+    return bool(getattr(fn, "_lackpy_async", False))

--- a/src/lackpy/service.py
+++ b/src/lackpy/service.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 import time
 from pathlib import Path
@@ -21,6 +22,7 @@ from .policy.layer import PolicyLayer
 from .policy.sources.kit import KitPolicySource
 from .lang.validator import ValidationResult, validate
 from .run.base import ExecutionResult
+from .run.bridge import AsyncBridge, is_async_callable
 from .run.runner import RestrictedRunner
 
 
@@ -78,6 +80,11 @@ class LackpyService:
         self._workspace = workspace or Path.cwd()
         self._config = config or load_config(self._workspace)
         self._runner = RestrictedRunner()
+        # Single-flight execution: serializes the process-global os.chdir in
+        # _execute so concurrent delegations can't race on cwd once an execution
+        # runs off the loop thread (the threaded/async path below).
+        self._exec_lock = asyncio.Lock()
+        self._bridge = AsyncBridge()
         self.toolbox = Toolbox()
         # Resolution mechanisms for directly-registered specs (tools themselves
         # come from sources, not these). Kept for back-compat with callers that
@@ -311,13 +318,37 @@ class LackpyService:
             interpreter=interpreter, kibitzer_session=self._kibitzer,
         )
 
-    def _execute(self, program: str, callables: dict[str, Any],
-                 param_values: dict[str, Any], kibitzer_session: Any = None) -> ExecutionResult:
+    async def _execute(self, program: str, callables: dict[str, Any],
+                       param_values: dict[str, Any], kibitzer_session: Any = None) -> ExecutionResult:
         """Run a (already validated) program through the restricted runner.
 
-        The single execution path shared by ``run_program`` and ``delegate``:
-        switch into the workspace, run, and always restore the prior cwd.
+        The single execution path shared by ``run_program`` and ``delegate``.
+        Held under ``_exec_lock`` so the process-global ``os.chdir`` is
+        single-flight regardless of which path runs.
+
+        - **Inline** (default): no loop-bound tools in the kit — run the sync
+          runner directly, exactly as before.
+        - **Threaded**: a tool is flagged loop-bound (e.g. an MCP proxy) — run the
+          sync runner via ``run_in_executor`` so the event loop stays free to
+          service coroutines those tools marshal back via :class:`AsyncBridge`.
         """
+        needs_loop = any(is_async_callable(fn) for fn in callables.values())
+        async with self._exec_lock:
+            if not needs_loop:
+                return self._run_sync(program, callables, param_values, kibitzer_session)
+            loop = asyncio.get_running_loop()
+            self._bridge.loop = loop
+            try:
+                return await loop.run_in_executor(
+                    None,
+                    lambda: self._run_sync(program, callables, param_values, kibitzer_session),
+                )
+            finally:
+                self._bridge.loop = None
+
+    def _run_sync(self, program: str, callables: dict[str, Any],
+                  param_values: dict[str, Any], kibitzer_session: Any = None) -> ExecutionResult:
+        """Switch into the workspace, run the program, restore cwd. Always sync."""
         prev_cwd = os.getcwd()
         try:
             os.chdir(self._workspace)
@@ -353,7 +384,7 @@ class LackpyService:
         validation = validate(program, allowed_names=allowed, extra_rules=rules)
         if not validation.valid:
             return ExecutionResult(success=False, error=f"Validation failed: {'; '.join(validation.errors)}")
-        return self._execute(program, resolved.callables, param_values)
+        return await self._execute(program, resolved.callables, param_values)
 
     async def delegate(self, intent: str, kit: str | list[str] | dict | None = None,
                        params: dict[str, Any] | None = None, sandbox: Any = None,
@@ -427,7 +458,7 @@ class LackpyService:
                         "correction_attempts": gen_result.correction_attempts,
                     }
 
-        exec_result = self._execute(
+        exec_result = await self._execute(
             gen_result.program, resolved.callables, param_values,
             kibitzer_session=self._kibitzer,
         )

--- a/src/lackpy/service.py
+++ b/src/lackpy/service.py
@@ -84,7 +84,11 @@ class LackpyService:
         # _execute so concurrent delegations can't race on cwd once an execution
         # runs off the loop thread (the threaded/async path below).
         self._exec_lock = asyncio.Lock()
+        # Bridge for execution-loop-local async tools. NB: MCP tools do NOT use
+        # this — they marshal to their own client-loop bridge (McpClient.bridge);
+        # this one is set per threaded run for any tool bound to the exec loop.
         self._bridge = AsyncBridge()
+        self._mcp_client: Any = None  # lazily created if [mcp_servers] are configured
         self.toolbox = Toolbox()
         # Resolution mechanisms for directly-registered specs (tools themselves
         # come from sources, not these). Kept for back-compat with callers that
@@ -116,7 +120,55 @@ class LackpyService:
         ]
         if self._config.tools:
             sources.append(ConfigToolSource(self._config.tools, name="config"))
+        sources.extend(self._build_mcp_sources())
         return sources
+
+    def _build_mcp_sources(self) -> list[Any]:
+        """One McpToolSource per configured [mcp_servers] entry (if mcp installed).
+
+        A server that fails to connect reports available()==False and is skipped
+        by add_source — one dead server never breaks the others.
+        """
+        if not self._config.mcp_servers:
+            return []
+        from .sources.mcp import mcp_available
+        if not mcp_available():
+            return []
+        from .sources.mcp.client import McpClient, McpServerSpec
+        from .sources.mcp.source import McpToolSource
+
+        if self._mcp_client is None:
+            self._mcp_client = McpClient()
+        sources: list[Any] = []
+        for server_id, cfg in self._config.mcp_servers.items():
+            spec = McpServerSpec(
+                server_id=server_id,
+                transport=cfg.get("transport", "stdio"),
+                command=cfg.get("command"),
+                args=cfg.get("args", []),
+                env=cfg.get("env"),
+                cwd=cfg.get("cwd"),
+                url=cfg.get("url"),
+                headers=cfg.get("headers"),
+            )
+            overrides = {
+                name: (g["w"], g["d"])
+                for name, t in (cfg.get("tools", {}) or {}).items()
+                if isinstance((g := (t or {}).get("grade")), dict) and "w" in g and "d" in g
+            }
+            sources.append(McpToolSource(spec, self._mcp_client, grade_overrides=overrides))
+        return sources
+
+    def close(self) -> None:
+        """Release background resources (the MCP client thread). Idempotent.
+
+        Best-effort: the MCP client runs on a daemon thread, so a one-shot
+        process (e.g. a CLI command) exits cleanly without calling this. Call it
+        for prompt cleanup in a long-lived host that creates many services.
+        """
+        if self._mcp_client is not None:
+            self._mcp_client.shutdown()
+            self._mcp_client = None
 
     def _init_inference_providers(self) -> None:
         templates_dir = self._config.config_dir / "templates"

--- a/src/lackpy/sources/mcp/__init__.py
+++ b/src/lackpy/sources/mcp/__init__.py
@@ -1,0 +1,18 @@
+"""MCP-discovered tool source (RFC 0002 increment 2b).
+
+Connects to MCP servers as a *client*, discovers their tools (full specs +
+grades from annotations), and exposes them as lackpy tools whose callables proxy
+``call_tool`` over a dedicated client event loop. Requires the optional ``mcp``
+dependency (``pip install lackpy[mcp]``).
+"""
+
+from __future__ import annotations
+
+
+def mcp_available() -> bool:
+    """Whether the optional ``mcp`` client SDK is importable."""
+    try:
+        import mcp  # noqa: F401
+        return True
+    except Exception:
+        return False

--- a/src/lackpy/sources/mcp/client.py
+++ b/src/lackpy/sources/mcp/client.py
@@ -1,0 +1,194 @@
+"""Dedicated-thread MCP client.
+
+All MCP I/O runs on one background thread + event loop owned by this client, so
+sessions open once and are reused across delegate calls and CLI invocations, and
+the bridge has a stable loop to marshal onto (RFC 0002 §3, §5; loop-ownership
+decision: dedicated client loop thread).
+
+The ``mcp`` SDK is imported lazily so importing this module never requires the
+optional dependency.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from concurrent.futures import Future as CFuture
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from typing import Any
+
+from ...run.bridge import AsyncBridge
+
+
+@dataclass
+class McpServerSpec:
+    """Connection spec for one MCP server."""
+
+    server_id: str
+    transport: str = "stdio"  # "stdio" | "http"
+    command: str | None = None
+    args: list[str] = field(default_factory=list)
+    env: dict[str, str] | None = None
+    cwd: str | None = None
+    url: str | None = None
+    headers: dict[str, str] | None = None
+
+
+class McpClient:
+    """Owns a background thread + event loop for all MCP I/O.
+
+    Each server gets a long-lived *manager task* that enters and exits its
+    session context in the SAME task (avoiding anyio's cross-task cancel-scope
+    error), keeping the session alive until shutdown.
+    """
+
+    def __init__(self) -> None:
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._thread: threading.Thread | None = None
+        self._ready = threading.Event()
+        self._shutdown_event: asyncio.Event | None = None
+        self._serve_tasks: list[asyncio.Task] = []
+        self._sessions: dict[str, Any] = {}
+        self._started = False
+        self.bridge = AsyncBridge()
+
+    # ---------- lifecycle ----------
+
+    def start(self) -> None:
+        if self._started:
+            return
+        self._thread = threading.Thread(target=self._thread_main, name="lackpy-mcp", daemon=True)
+        self._thread.start()
+        self._ready.wait()
+        self._started = True
+
+    def _thread_main(self) -> None:
+        self._loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(self._loop)
+        self._shutdown_event = asyncio.Event()
+        self.bridge.loop = self._loop
+        self._ready.set()
+        self._loop.run_forever()
+        # After stop(): drain anything still pending, then close.
+        pending = asyncio.all_tasks(self._loop)
+        for t in pending:
+            t.cancel()
+        if pending:
+            self._loop.run_until_complete(asyncio.gather(*pending, return_exceptions=True))
+        self._loop.close()
+
+    def shutdown(self) -> None:
+        if not self._started or self._loop is None:
+            return
+        try:
+            fut = asyncio.run_coroutine_threadsafe(self._drain(), self._loop)
+            fut.result(timeout=5)
+        except Exception:
+            pass
+        self._loop.call_soon_threadsafe(self._loop.stop)
+        if self._thread:
+            self._thread.join(timeout=5)
+        self._started = False
+
+    async def _drain(self) -> None:
+        if self._shutdown_event is not None:
+            self._shutdown_event.set()
+        if self._serve_tasks:
+            await asyncio.gather(*self._serve_tasks, return_exceptions=True)
+
+    # ---------- connect / discover ----------
+
+    def connect(self, spec: McpServerSpec, timeout: float = 30.0) -> list[Any]:
+        """Open a session to ``spec`` and return its discovered tools.
+
+        Blocking; safe to call from the service's (sync) init on any thread.
+        """
+        if not self._started:
+            self.start()
+        ready: CFuture = CFuture()
+
+        def _schedule() -> None:
+            task = self._loop.create_task(self._serve(spec, ready))  # type: ignore[union-attr]
+            self._serve_tasks.append(task)
+
+        self._loop.call_soon_threadsafe(_schedule)  # type: ignore[union-attr]
+        return ready.result(timeout)
+
+    async def _serve(self, spec: McpServerSpec, ready: CFuture) -> None:
+        from mcp import ClientSession
+
+        try:
+            async with self._open_transport(spec) as (read, write):
+                async with ClientSession(read, write) as session:
+                    await session.initialize()
+                    self._sessions[spec.server_id] = session
+                    tools = (await session.list_tools()).tools
+                    ready.set_result(tools)
+                    await self._shutdown_event.wait()  # hold the context open in THIS task
+        except Exception as e:  # noqa: BLE001
+            if not ready.done():
+                ready.set_exception(e)
+        finally:
+            self._sessions.pop(spec.server_id, None)
+
+    @asynccontextmanager
+    async def _open_transport(self, spec: McpServerSpec):
+        if spec.transport == "stdio":
+            from mcp import StdioServerParameters
+            from mcp.client.stdio import stdio_client
+
+            params = StdioServerParameters(
+                command=spec.command, args=spec.args, env=spec.env, cwd=spec.cwd,
+            )
+            async with stdio_client(params) as (read, write):
+                yield read, write
+        elif spec.transport == "http":
+            from mcp.client.streamable_http import streamablehttp_client
+
+            async with streamablehttp_client(spec.url, headers=spec.headers) as (read, write, _):
+                yield read, write
+        else:
+            raise ValueError(f"Unknown MCP transport: {spec.transport!r}")
+
+    # ---------- call ----------
+
+    def call(self, server_id: str, name: str, arguments: dict[str, Any] | None,
+             timeout: float | None = None) -> Any:
+        """Invoke an MCP tool and return its unwrapped result (sync; for proxies)."""
+        return self.bridge.call_sync(self._call(server_id, name, arguments), timeout)
+
+    async def _call(self, server_id: str, name: str, arguments: dict[str, Any] | None) -> Any:
+        session = self._sessions.get(server_id)
+        if session is None:
+            raise RuntimeError(f"MCP server {server_id!r} is not connected")
+        result = await session.call_tool(name, arguments or {})
+        if result.isError:
+            raise RuntimeError(_format_error(result))
+        return _unwrap(result)
+
+
+def _unwrap(result: Any) -> Any:
+    """Normalize a CallToolResult to a plain Python value.
+
+    structured output → its value (unwrapping fastmcp's ``{"result": ...}``);
+    a single text block → its string; multiple → list of strings.
+    """
+    sc = getattr(result, "structuredContent", None)
+    if isinstance(sc, dict):
+        if set(sc.keys()) == {"result"}:
+            return sc["result"]
+        return sc
+    blocks = result.content or []
+    texts = [b.text for b in blocks if getattr(b, "type", None) == "text"]
+    if len(texts) == 1:
+        return texts[0]
+    if texts:
+        return texts
+    return None
+
+
+def _format_error(result: Any) -> str:
+    blocks = getattr(result, "content", None) or []
+    texts = [b.text for b in blocks if getattr(b, "type", None) == "text"]
+    return "; ".join(texts) or "MCP tool returned an error"

--- a/src/lackpy/sources/mcp/grade.py
+++ b/src/lackpy/sources/mcp/grade.py
@@ -1,0 +1,36 @@
+"""Derive a lackpy security Grade(w, d) from MCP tool annotations (RFC 0002 §6).
+
+MCP annotations are advisory booleans. We map them conservatively: any relevant
+hint absent ⇒ Grade(3, 3). External coupling raises w; destructiveness /
+non-idempotence raises d. Config overrides always win (applied in the source).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from ...lang.grader import Grade
+
+CONSERVATIVE = Grade(w=3, d=3)
+
+
+def grade_from_annotations(ann: Any) -> Grade:
+    """Map a ToolAnnotations-like object (or None) to a Grade."""
+    if ann is None:
+        return CONSERVATIVE
+    read_only = getattr(ann, "readOnlyHint", None)
+    open_world = getattr(ann, "openWorldHint", None)
+    idempotent = getattr(ann, "idempotentHint", None)
+    destructive = getattr(ann, "destructiveHint", None)
+
+    if read_only is True:
+        if open_world is False:
+            return Grade(w=1, d=0)   # local read, no effects
+        if open_world is True:
+            return Grade(w=2, d=1)   # network read couples to external systems
+        return CONSERVATIVE          # open-world unknown
+    if read_only is False:
+        if idempotent is True and destructive is False:
+            return Grade(w=3, d=2)   # scoped write, safe to retry
+        return CONSERVATIVE          # non-idempotent / destructive / unknown
+    return CONSERVATIVE              # read-only unknown

--- a/src/lackpy/sources/mcp/source.py
+++ b/src/lackpy/sources/mcp/source.py
@@ -1,0 +1,115 @@
+"""McpToolSource — a ToolSource backed by one MCP server.
+
+Discovers the server's tools (via a shared :class:`McpClient`), builds full
+``ToolSpec``s (inputSchema → args, annotations → grade), and resolves callables
+to async proxies that marshal ``call_tool`` onto the client loop.
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any, Callable
+
+from ...kit.toolbox import ArgSpec, ToolSpec
+from ...run.bridge import mark_async
+from .client import McpClient, McpServerSpec
+from .grade import grade_from_annotations
+
+# JSON Schema primitive → lackpy ArgSpec type string (display + resolve_python_type).
+_JSON_TYPE_MAP = {
+    "string": "str", "integer": "int", "number": "float",
+    "boolean": "bool", "object": "dict", "array": "list",
+}
+
+
+class McpToolSource:
+    """Exposes one MCP server's tools as lackpy tools.
+
+    Args:
+        spec: Connection spec for the server.
+        client: Shared MCP client owning the background loop/sessions.
+        grade_overrides: Optional ``{tool_name: (w, d)}`` overrides (config wins).
+        connect_timeout: Per-server connect/discovery timeout (seconds).
+    """
+
+    def __init__(self, spec: McpServerSpec, client: McpClient,
+                 grade_overrides: dict[str, tuple[int, int]] | None = None,
+                 connect_timeout: float = 30.0) -> None:
+        self._spec = spec
+        self._client = client
+        self._grade_overrides = grade_overrides or {}
+        self._connect_timeout = connect_timeout
+        self._discovered: list[Any] | None = None
+
+    @property
+    def name(self) -> str:
+        return f"mcp:{self._spec.server_id}"
+
+    def available(self) -> bool:
+        try:
+            self._ensure_discovered()
+            return True
+        except Exception:
+            return False
+
+    def discover(self) -> list[ToolSpec]:
+        return [self._to_spec(t) for t in self._ensure_discovered()]
+
+    def resolve(self, spec: ToolSpec) -> Callable[..., Any]:
+        server_id = self._spec.server_id
+        client = self._client
+        mcp_name = spec.provider_config.get("mcp_name", spec.name)
+        param_names = [a.name for a in spec.args]
+
+        def proxy(*args: Any, **kwargs: Any) -> Any:
+            call_args = dict(zip(param_names, args))
+            call_args.update(kwargs)
+            return client.call(server_id, mcp_name, call_args)
+
+        # A real signature so make_traced maps positional args to names.
+        proxy.__signature__ = inspect.Signature(
+            [inspect.Parameter(n, inspect.Parameter.POSITIONAL_OR_KEYWORD) for n in param_names]
+        )
+        proxy.__name__ = spec.name
+        return mark_async(proxy)
+
+    # ---------- internals ----------
+
+    def _ensure_discovered(self) -> list[Any]:
+        if self._discovered is None:
+            self._discovered = self._client.connect(self._spec, timeout=self._connect_timeout)
+        return self._discovered
+
+    def _to_spec(self, tool: Any) -> ToolSpec:
+        override = self._grade_overrides.get(tool.name)
+        if override is not None:
+            gw, gd = override
+        else:
+            g = grade_from_annotations(getattr(tool, "annotations", None))
+            gw, gd = g.w, g.d
+        return ToolSpec(
+            name=tool.name,
+            provider=self.name,
+            provider_config={"mcp_name": tool.name},
+            description=tool.description or "",
+            args=_args_from_schema(getattr(tool, "inputSchema", None)),
+            returns="Any",
+            grade_w=gw,
+            effects_ceiling=gd,
+        )
+
+
+def _args_from_schema(schema: Any) -> list[ArgSpec]:
+    if not isinstance(schema, dict):
+        return []
+    props = schema.get("properties", {})
+    args: list[ArgSpec] = []
+    for pname, pdef in props.items():
+        pdef = pdef if isinstance(pdef, dict) else {}
+        json_type = pdef.get("type", "Any")
+        args.append(ArgSpec(
+            name=pname,
+            type=_JSON_TYPE_MAP.get(json_type, "Any"),
+            description=pdef.get("description", ""),
+        ))
+    return args

--- a/tests/fixtures/mcp_echo_server.py
+++ b/tests/fixtures/mcp_echo_server.py
@@ -1,0 +1,22 @@
+"""Minimal fastmcp stdio server used as an MCP-client integration fixture."""
+
+from mcp.server.fastmcp import FastMCP
+from mcp.types import ToolAnnotations
+
+mcp = FastMCP("echo-test")
+
+
+@mcp.tool(annotations=ToolAnnotations(readOnlyHint=True, openWorldHint=False))
+def echo(text: str) -> str:
+    """Echo back the given text."""
+    return text
+
+
+@mcp.tool()
+def add(a: int, b: int) -> int:
+    """Add two integers."""
+    return a + b
+
+
+if __name__ == "__main__":
+    mcp.run()

--- a/tests/run/test_async_bridge.py
+++ b/tests/run/test_async_bridge.py
@@ -1,0 +1,120 @@
+"""The sync↔async execution bridge (RFC 0002 increment 2a).
+
+Exercises the bridge with a fake async tool — no MCP, no subprocess — so the
+concurrency correctness (no deadlock, timeout handling, single-flight cwd lock)
+is tested deterministically.
+"""
+
+import asyncio
+
+from lackpy.kit.toolbox import ArgSpec, ToolSpec
+from lackpy.run.bridge import mark_async
+from lackpy.service import LackpyService
+
+
+class _FuncSource:
+    """Minimal ToolSource exposing one named callable (test double)."""
+
+    def __init__(self, spec: ToolSpec, fn):
+        self._spec = spec
+        self._fn = fn
+
+    @property
+    def name(self) -> str:
+        return "test"
+
+    def available(self) -> bool:
+        return True
+
+    def discover(self):
+        return [self._spec]
+
+    def resolve(self, spec):
+        return self._fn
+
+
+def _spec(name: str, arg: str, arg_type: str = "int", returns: str = "int") -> ToolSpec:
+    return ToolSpec(name=name, provider="test",
+                    args=[ArgSpec(name=arg, type=arg_type)], returns=returns)
+
+
+async def test_async_tool_runs_through_bridge(tmp_path):
+    svc = LackpyService(workspace=tmp_path)
+    bridge = svc._bridge
+
+    async def _ainc(x):
+        await asyncio.sleep(0.01)
+        return x + 1
+
+    @mark_async
+    def proxy(x):
+        return bridge.call_sync(_ainc(x))
+
+    svc.toolbox.add_source(_FuncSource(_spec("ainc", "x"), proxy))
+    res = await svc.run_program("y = ainc(1)\ny", kit=["ainc"])
+
+    assert res.success, res.error
+    assert res.output == 2
+    assert res.trace.entries[0].tool == "ainc"
+    assert res.trace.entries[0].success
+
+
+async def test_async_tool_timeout_yields_failed_result(tmp_path):
+    svc = LackpyService(workspace=tmp_path)
+    bridge = svc._bridge
+
+    async def _hang(x):
+        await asyncio.sleep(10)
+        return x
+
+    @mark_async
+    def proxy(x):
+        return bridge.call_sync(_hang(x), timeout=0.1)
+
+    svc.toolbox.add_source(_FuncSource(_spec("hang", "x"), proxy))
+    res = await svc.run_program("y = hang(1)\ny", kit=["hang"])
+
+    assert not res.success
+    assert "timed out" in (res.error or "")
+    # Failure is recorded in the trace like any other tool error.
+    assert res.trace.entries and res.trace.entries[0].success is False
+
+
+async def test_exec_lock_serializes_concurrent_executions(tmp_path):
+    # Proves the single-flight lock: once execution runs off the loop thread, two
+    # overlapping delegations must NOT interleave (which would race the global cwd).
+    svc = LackpyService(workspace=tmp_path)
+    bridge = svc._bridge
+    events: list[str] = []
+
+    async def _rec(tag):
+        events.append(f"{tag}_in")
+        await asyncio.sleep(0.02)
+        events.append(f"{tag}_out")
+        return tag
+
+    @mark_async
+    def proxy(tag):
+        return bridge.call_sync(_rec(tag))
+
+    svc.toolbox.add_source(_FuncSource(_spec("rec", "tag", "str", "str"), proxy))
+
+    async def run(tag):
+        return await svc.run_program(f"r = rec({tag!r})\nr", kit=["rec"])
+
+    res_a, res_b = await asyncio.gather(run("A"), run("B"))
+
+    assert res_a.success and res_b.success
+    assert events in (
+        ["A_in", "A_out", "B_in", "B_out"],
+        ["B_in", "B_out", "A_in", "A_out"],
+    ), f"interleaved -> lock not holding: {events}"
+
+
+async def test_inline_path_still_used_without_async_tools(tmp_path):
+    # No loop-bound tool -> inline (non-threaded) path; bridge loop never set.
+    (tmp_path / "f.txt").write_text("data")
+    svc = LackpyService(workspace=tmp_path)
+    res = await svc.run_program("c = read_file('f.txt')\nc", kit=["read_file"])
+    assert res.success and res.output == "data"
+    assert svc._bridge.loop is None

--- a/tests/sources/test_mcp_client.py
+++ b/tests/sources/test_mcp_client.py
@@ -1,0 +1,40 @@
+"""Direct McpClient integration test against a real fastmcp stdio server."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from lackpy.sources.mcp import mcp_available
+
+pytestmark = pytest.mark.skipif(not mcp_available(), reason="mcp SDK not installed")
+
+FIXTURE = str(Path(__file__).parent.parent / "fixtures" / "mcp_echo_server.py")
+
+
+def _spec():
+    from lackpy.sources.mcp.client import McpServerSpec
+
+    return McpServerSpec(
+        server_id="echo", transport="stdio", command=sys.executable, args=[FIXTURE]
+    )
+
+
+def test_connect_discover_call_shutdown():
+    from lackpy.sources.mcp.client import McpClient
+
+    client = McpClient()
+    try:
+        tools = client.connect(_spec(), timeout=30)
+        names = {t.name for t in tools}
+        assert {"echo", "add"} <= names
+
+        # echo carries readOnlyHint + closed-world annotations
+        echo = next(t for t in tools if t.name == "echo")
+        assert echo.annotations is not None
+        assert echo.annotations.readOnlyHint is True
+
+        assert client.call("echo", "echo", {"text": "hi"}) == "hi"
+        assert client.call("echo", "add", {"a": 2, "b": 3}) == 5
+    finally:
+        client.shutdown()

--- a/tests/sources/test_mcp_source.py
+++ b/tests/sources/test_mcp_source.py
@@ -1,0 +1,93 @@
+"""McpToolSource: grade mapping, discovery, and end-to-end tool calls."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+from lackpy.sources.mcp import mcp_available
+
+pytestmark = pytest.mark.skipif(not mcp_available(), reason="mcp SDK not installed")
+
+FIXTURE = str(Path(__file__).parent.parent / "fixtures" / "mcp_echo_server.py")
+
+
+def _server_cfg() -> dict:
+    return {"transport": "stdio", "command": sys.executable, "args": [FIXTURE]}
+
+
+def test_grade_from_annotations_mapping():
+    from lackpy.lang.grader import Grade
+    from lackpy.sources.mcp.grade import grade_from_annotations
+
+    class _Ann:
+        def __init__(self, **k):
+            self.readOnlyHint = k.get("readOnlyHint")
+            self.openWorldHint = k.get("openWorldHint")
+            self.idempotentHint = k.get("idempotentHint")
+            self.destructiveHint = k.get("destructiveHint")
+
+    assert grade_from_annotations(None) == Grade(3, 3)
+    assert grade_from_annotations(_Ann(readOnlyHint=True, openWorldHint=False)) == Grade(1, 0)
+    assert grade_from_annotations(_Ann(readOnlyHint=True, openWorldHint=True)) == Grade(2, 1)
+    assert grade_from_annotations(_Ann(readOnlyHint=False, idempotentHint=True, destructiveHint=False)) == Grade(3, 2)
+    assert grade_from_annotations(_Ann(readOnlyHint=False, destructiveHint=True)) == Grade(3, 3)
+    assert grade_from_annotations(_Ann(readOnlyHint=True)) == Grade(3, 3)  # open-world unknown
+
+
+def test_source_discovers_specs_with_grade_and_args():
+    from lackpy.sources.mcp.client import McpClient, McpServerSpec
+    from lackpy.sources.mcp.source import McpToolSource
+
+    client = McpClient()
+    try:
+        spec = McpServerSpec(server_id="echo", transport="stdio",
+                             command=sys.executable, args=[FIXTURE])
+        src = McpToolSource(spec, client)
+        assert src.available()
+        specs = {s.name: s for s in src.discover()}
+        assert {"echo", "add"} <= set(specs)
+        # echo: readOnly + closed-world -> (1, 0)
+        assert (specs["echo"].grade_w, specs["echo"].effects_ceiling) == (1, 0)
+        assert specs["echo"].provider == "mcp:echo"
+        assert [a.name for a in specs["echo"].args] == ["text"]
+        assert specs["echo"].args[0].type == "str"
+    finally:
+        client.shutdown()
+
+
+def test_grade_override_wins():
+    from lackpy.sources.mcp.client import McpClient, McpServerSpec
+    from lackpy.sources.mcp.source import McpToolSource
+
+    client = McpClient()
+    try:
+        spec = McpServerSpec(server_id="echo", transport="stdio",
+                             command=sys.executable, args=[FIXTURE])
+        src = McpToolSource(spec, client, grade_overrides={"echo": (3, 3)})
+        specs = {s.name: s for s in src.discover()}
+        assert (specs["echo"].grade_w, specs["echo"].effects_ceiling) == (3, 3)
+    finally:
+        client.shutdown()
+
+
+async def test_run_program_calls_mcp_tool_end_to_end(tmp_path):
+    from lackpy.config import LackpyConfig
+    from lackpy.service import LackpyService
+
+    cfg = LackpyConfig(mcp_servers={"echo": _server_cfg()})
+    svc = LackpyService(workspace=tmp_path, config=cfg)
+    try:
+        names = {t["name"] for t in svc.toolbox_list()}
+        assert {"echo", "add"} <= names
+
+        res = await svc.run_program("r = echo(text='hi')\nr", kit=["echo"])
+        assert res.success, res.error
+        assert res.output == "hi"
+        assert res.trace.entries[0].tool == "echo"
+
+        res2 = await svc.run_program("s = add(a=2, b=3)\ns", kit=["add"])
+        assert res2.success, res2.error
+        assert res2.output == 5
+    finally:
+        svc.close()


### PR DESCRIPTION
Implements RFC 0002 increment 2: lackpy programs (synchronous) can now call MCP tools (async) without deadlocking, and tools can be discovered from MCP servers.

## 2a — sync↔async bridge (`d36a4cb`)
- `run/bridge.py`: `AsyncBridge` marshals a coroutine from a worker thread onto a target loop (`run_coroutine_threadsafe` + timeout→`TimeoutError`); `mark_async`/`is_async_callable`.
- `service._execute` is now async, held under an `asyncio.Lock` so the process-global `os.chdir` stays **single-flight** even when execution runs off the loop thread. **Lazy** path-select: inline (unchanged) unless a kit carries a loop-bound tool, else `run_in_executor`.
- Tests (no MCP): async tool runs + traces; hanging coro → timeout → failed result; two overlapping executions don't interleave (lock proof); inline path unchanged.

## 2b — MCP client + `McpToolSource` (`cf382b9`)
- First MCP **client**. `McpClient` owns a dedicated background thread + event loop (loop-ownership decision: dedicated client loop, so sessions open once and reuse across delegate calls AND per-command CLI invocations, and the bridge has a stable marshal target). Per-server **manager task** enters/exits the `ClientSession` in the same task (avoids anyio cross-task cancel-scope). stdio + streamable-http; lazy `mcp` imports (optional `lackpy[mcp]`).
- `McpToolSource`: eager discovery, `inputSchema`→args, annotations→`Grade` (conservative when hints absent; config override wins), async proxy callables (real `__signature__`). One dead server is skipped, never fatal.
- `[mcp_servers]` config; service owns the client + `close()` (daemon thread → best-effort).

## Verification
- **902 passed, 1 skipped**; lint clean. End-to-end test runs the dangerous path (pytest loop → worker thread → separate client loop, three threads, no deadlock) against a real fastmcp stdio fixture server. Grade mapping unit-tested.

## Not in scope (RFC increments 3–5)
Multi-server namespacing + host-config ingestion, virtual/harness tools, kits→profile layer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)