### PR TITLE
feat: multi-source precedence + MCP host-config ingestion (RFC 0002 increment 3)

### DIFF
--- a/docs/design/tool-sources.md
+++ b/docs/design/tool-sources.md
@@ -1,9 +1,9 @@
 # RFC 0002 — Tool sources (config, MCP, virtual) & the sync↔async bridge
 
 !!! note "Status"
-    Increment 1 (config-defined source) and increment 2 (async bridge + MCP client
-    for own `[mcp_servers]`) are **implemented**. Increments 3–5 (multi/host config
-    + namespacing, virtual tools, kits→profile) are **design-only** here. Siblings:
+    Increments 1–3 are **implemented** (config-defined source; async bridge + MCP
+    client; multi-source precedence + host-config ingestion). Increments 4–5
+    (virtual tools, kits→profile) are **design-only** here. Siblings:
     [Direction](direction.md), [Interpreter Types](interpreter-types.md), RFC 0001
     (the `lackpy-lang` leaf split).
 
@@ -86,21 +86,27 @@ first MCP *client*.
   `inputSchema`→`ArgSpec`s (unknown/nested → `type="Any"`, matching
   `resolve_python_type`'s fallback), `annotations`→grade (§6).
 
-## 4. Multi-inventory merge, namespacing, precedence (deferred)
+## 4. Multi-inventory merge, namespacing, precedence (implemented)
 
 Tension: host convention uses long names (`mcp__claude_ai_Gmail__create_draft`), but
 `toolbox._MASKING_NAMES` + the `register_tool` warning exist precisely because long/
 confusing names degrade the small (1.5B) generator lackpy targets.
 
-**Recommendation — short-by-default, qualify-on-collision:** each source contributes
-tools under their bare name; on collision the higher-precedence tool keeps the bare
-name and the loser is *also* kept as `<server>__<tool>`. Names hitting `_MASKING_NAMES`
-auto-qualify + warn (reuse existing machinery).
+**Implemented — short names, drop-with-log on collision (v1):** each source contributes
+tools under their bare name; on collision the higher-precedence source keeps the bare
+name and the shadowed tool is **dropped and logged** (`logger.info`). v1 does *not*
+keep a `<server>__<tool>` alias — the small models lackpy targets never call qualified
+names, so the alias machinery would serve no real path; add it in a later increment
+only if a workflow needs a shadowed tool. Masking names stay **warn-only** (auto-qualify
+deferred).
 
-**Precedence (deterministic), highest wins the bare name:** own `[mcp_servers]` → host
-configs (listed order) → local config-defined/builtins (auditable local source wins).
-Applied once at inventory assembly; the resolved name set feeds `KitPolicySource` and
-`format_description` unchanged.
+**Precedence (deterministic), highest wins the bare name** — *auditable local source
+wins*: user config `[[tools]]` (20) > shipped defaults/builtins (10) > own
+`[mcp_servers]` (5) > host configs (4, descending per file so the earlier file wins,
+floored at 1). Equal precedence → the later-added source wins (this is how a user
+`[[tools]]` entry overrides a default of the same name). Directly-`register_tool`'d
+tools use `inf` (always authoritative). The resolved name set feeds `KitPolicySource`
+and `format_description` unchanged.
 
 ## 5. The sync↔async bridge (centerpiece, deferred)
 
@@ -232,7 +238,9 @@ kibitzer chain is unchanged; new sources plug in by populating grades correctly.
    2b: dedicated-loop `McpClient` (loop-ownership decision = dedicated client
    thread, so eager discovery + session reuse compose across the MCP-server and
    per-command CLI contexts), `McpToolSource`, grade-from-hints; own `[mcp_servers]`.
-3. **Multi/host config + namespacing** (§3.4, §4) — *next*.
+3. **Multi/host config + namespacing** — *implemented*. Precedence + drop-with-log
+   collision merge in `Toolbox` (§4); `[mcp].host_configs` ingestion of external
+   `mcpServers` files at descending precedence (§3.4).
 4. **Virtual/harness tools** (§7).
 5. **kits→profile layer** on top of sources, retiring "kit" ([direction.md](direction.md) §2).
 

--- a/src/lackpy/config.py
+++ b/src/lackpy/config.py
@@ -28,6 +28,7 @@ class LackpyConfig:
     tool_providers: dict[str, dict[str, Any]] = field(default_factory=dict)
     tools: list[dict[str, Any]] = field(default_factory=list)
     mcp_servers: dict[str, dict[str, Any]] = field(default_factory=dict)
+    mcp_host_configs: list[str] = field(default_factory=list)
     config_dir: Path = field(default_factory=lambda: Path(".lackpy"))
 
 
@@ -46,6 +47,7 @@ def load_config(workspace: Path | None = None) -> LackpyConfig:
     tool_providers = data.get("tool_providers", {})
     tools = data.get("tools", [])
     mcp_servers = data.get("mcp_servers", {})
+    mcp_host_configs = data.get("mcp", {}).get("host_configs", [])
     providers: dict[str, dict[str, Any]] = {}
     for name, cfg in inference.get("providers", {}).items():
         providers[name] = cfg
@@ -60,5 +62,6 @@ def load_config(workspace: Path | None = None) -> LackpyConfig:
         tool_providers=tool_providers,
         tools=tools,
         mcp_servers=mcp_servers,
+        mcp_host_configs=mcp_host_configs,
         config_dir=config_dir,
     )

--- a/src/lackpy/kit/toolbox.py
+++ b/src/lackpy/kit/toolbox.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import logging
 import sys
 import warnings
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
 
 # Names that will confuse small language models if used as tool names.
 # Includes Python stdlib top-level modules and builtin functions.
@@ -79,23 +82,41 @@ class Toolbox:
         # (the source resolves its own callables; takes precedence over the
         # name→provider dispatch used by directly-registered tools).
         self._spec_owner: dict[str, Any] = {}
+        # Precedence of the source that currently holds each (bare) tool name.
+        # Higher wins; equal → later-added wins. Directly-registered tools use inf.
+        self._precedence: dict[str, float] = {}
 
-    def add_source(self, source: Any) -> None:
+    def add_source(self, source: Any, precedence: float = 0) -> None:
         """Discover and register every tool a :class:`ToolSource` provides.
 
-        The source owns resolution for the tools it contributes. A later source
-        overrides an earlier one on name collision (so user config beats shipped
-        defaults). No-op if the source reports itself unavailable.
+        On a name collision the higher-``precedence`` source keeps the name
+        (equal precedence → the later-added source wins); the shadowed tool is
+        **dropped and logged** (v1 has no qualified alias — the small models
+        lackpy targets never call ``server__tool`` names). No-op if the source
+        reports itself unavailable.
 
         Args:
             source: An object with ``available()``, ``discover()`` and
                 ``resolve(spec)`` (the ToolSource protocol).
+            precedence: Higher wins the bare name. Service order: user config
+                ``[[tools]]`` > shipped defaults > own ``[mcp_servers]`` > host.
         """
         if not source.available():
             return
         for spec in source.discover():
-            self.register_tool(spec)          # clears any prior owner for this name
-            self._spec_owner[spec.name] = source  # this source now owns resolution
+            name = spec.name
+            held = self._precedence.get(name)
+            if held is not None and precedence < held:
+                logger.info(
+                    "tool %r from source %r shadowed by higher-precedence %r",
+                    name, getattr(source, "name", "?"),
+                    getattr(self._spec_owner.get(name), "name", "?"),
+                )
+                continue
+            self._warn_if_masking(name)
+            self.tools[name] = spec
+            self._spec_owner[name] = source
+            self._precedence[name] = precedence
 
     def register_provider(self, provider: Any) -> None:
         """Register a tool provider plugin and load its tools into the registry.
@@ -116,19 +137,24 @@ class Toolbox:
             UserWarning: If the tool name masks a Python stdlib module or builtin,
                 which causes small language models to generate incorrect code.
         """
-        if spec.name in _MASKING_NAMES:
+        self._warn_if_masking(spec.name)
+        # A directly-registered tool is authoritative: it resolves via provider
+        # dispatch (drop any source ownership) and outranks every source so a
+        # later add_source can't steal the name.
+        self._spec_owner.pop(spec.name, None)
+        self._precedence[spec.name] = float("inf")
+        self.tools[spec.name] = spec
+
+    def _warn_if_masking(self, name: str) -> None:
+        if name in _MASKING_NAMES:
             warnings.warn(
-                f"Tool name '{spec.name}' masks a Python stdlib module or builtin. "
-                f"Small language models may generate `{spec.name}.{spec.name}()` or "
-                f"`import {spec.name}` instead of calling the tool directly. "
-                f"Consider a more specific name (e.g. '{spec.name}_file').",
+                f"Tool name '{name}' masks a Python stdlib module or builtin. "
+                f"Small language models may generate `{name}.{name}()` or "
+                f"`import {name}` instead of calling the tool directly. "
+                f"Consider a more specific name (e.g. '{name}_file').",
                 UserWarning,
                 stacklevel=2,
             )
-        # A directly-registered tool resolves via provider dispatch; drop any
-        # prior source ownership for this name so a later register_tool wins.
-        self._spec_owner.pop(spec.name, None)
-        self.tools[spec.name] = spec
 
     def resolve(self, name: str) -> Callable[..., Any]:
         """Return the callable implementation for a named tool.

--- a/src/lackpy/service.py
+++ b/src/lackpy/service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import time
 from pathlib import Path
@@ -24,6 +25,8 @@ from .lang.validator import ValidationResult, validate
 from .run.base import ExecutionResult
 from .run.bridge import AsyncBridge, is_async_callable
 from .run.runner import RestrictedRunner
+
+logger = logging.getLogger(__name__)
 
 
 def _strip_top_level_return(program: str) -> str:
@@ -95,8 +98,8 @@ class LackpyService:
         # register their own provider="builtin"/"python" specs.
         self.toolbox.register_provider(BuiltinProvider())
         self.toolbox.register_provider(PythonProvider())
-        for source in self._build_tool_sources():
-            self.toolbox.add_source(source)
+        for source, precedence in self._build_tool_sources():
+            self.toolbox.add_source(source, precedence)
         self._inference_providers: list = []
         self._init_inference_providers()
         self._policy = PolicyLayer()
@@ -104,43 +107,53 @@ class LackpyService:
         self._kibitzer: Any = None
         self._init_kibitzer()
 
-    def _build_tool_sources(self) -> list[Any]:
-        """Assemble the tool sources that populate the toolbox.
+    # Source precedences (higher wins the bare name on collision; see Toolbox).
+    _PREC_CONFIG = 20    # user [[tools]]
+    _PREC_DEFAULT = 10   # shipped builtins
+    _PREC_OWN_MCP = 5    # own [mcp_servers]
+    _PREC_HOST_MCP = 4   # host configs (earlier file higher; floors at 1)
 
-        Shipped defaults first, then user-configured ``[[tools]]`` (so a user
-        definition overrides a default of the same name). Future MCP-discovered
-        and virtual/harness sources slot into this list (see
-        docs/design/tool-sources.md).
+    def _build_tool_sources(self) -> list[tuple[Any, float]]:
+        """Assemble (source, precedence) pairs that populate the toolbox.
+
+        Precedence: user ``[[tools]]`` > shipped defaults > own ``[mcp_servers]`` >
+        host configs (auditable local source wins; see docs/design/tool-sources.md §4).
         """
         from .sources import load_default_tool_defs
         from .sources.config import ConfigToolSource
 
-        sources: list[Any] = [
-            ConfigToolSource(load_default_tool_defs(), name="default"),
+        sources: list[tuple[Any, float]] = [
+            (ConfigToolSource(load_default_tool_defs(), name="default"), self._PREC_DEFAULT),
         ]
         if self._config.tools:
-            sources.append(ConfigToolSource(self._config.tools, name="config"))
+            sources.append((ConfigToolSource(self._config.tools, name="config"), self._PREC_CONFIG))
         sources.extend(self._build_mcp_sources())
         return sources
 
-    def _build_mcp_sources(self) -> list[Any]:
-        """One McpToolSource per configured [mcp_servers] entry (if mcp installed).
+    def _build_mcp_sources(self) -> list[tuple[Any, float]]:
+        """McpToolSources for own [mcp_servers] and ingested host configs.
 
         A server that fails to connect reports available()==False and is skipped
-        by add_source — one dead server never breaks the others.
+        by add_source — one dead server (or one malformed host config) never
+        breaks the others.
         """
-        if not self._config.mcp_servers:
+        own = self._config.mcp_servers
+        host_paths = self._config.mcp_host_configs
+        if not own and not host_paths:
             return []
         from .sources.mcp import mcp_available
         if not mcp_available():
             return []
-        from .sources.mcp.client import McpClient, McpServerSpec
+        from .sources.mcp.client import McpServerSpec, McpClient
+        from .sources.mcp.host_config import load_host_servers
         from .sources.mcp.source import McpToolSource
 
         if self._mcp_client is None:
             self._mcp_client = McpClient()
-        sources: list[Any] = []
-        for server_id, cfg in self._config.mcp_servers.items():
+        out: list[tuple[Any, float]] = []
+
+        # own servers — highest MCP precedence
+        for server_id, cfg in own.items():
             spec = McpServerSpec(
                 server_id=server_id,
                 transport=cfg.get("transport", "stdio"),
@@ -156,8 +169,20 @@ class LackpyService:
                 for name, t in (cfg.get("tools", {}) or {}).items()
                 if isinstance((g := (t or {}).get("grade")), dict) and "w" in g and "d" in g
             }
-            sources.append(McpToolSource(spec, self._mcp_client, grade_overrides=overrides))
-        return sources
+            out.append((McpToolSource(spec, self._mcp_client, grade_overrides=overrides),
+                        self._PREC_OWN_MCP))
+
+        # host configs — earlier file wins (descending precedence, floored at 1)
+        for i, path in enumerate(host_paths):
+            prec = max(1.0, self._PREC_HOST_MCP - i)
+            try:
+                specs = load_host_servers(path)
+            except Exception:
+                logger.warning("skipping unreadable MCP host config: %s", path)
+                continue
+            for spec in specs:
+                out.append((McpToolSource(spec, self._mcp_client), prec))
+        return out
 
     def close(self) -> None:
         """Release background resources (the MCP client thread). Idempotent.

--- a/src/lackpy/sources/mcp/host_config.py
+++ b/src/lackpy/sources/mcp/host_config.py
@@ -1,0 +1,44 @@
+"""Read external *host* MCP config files into McpServerSpec descriptors.
+
+Normalizes the common ``{"mcpServers": {name: {...}}}`` shape used by Claude
+Desktop / Cursor / Claude Code. stdio entries use ``command``/``args``/``env``;
+HTTP entries use ``url``/``headers``. Host configs are an explicit opt-in
+(``[mcp].host_configs``) — lackpy never auto-discovers them, since they spawn
+subprocesses lackpy didn't author.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+
+from .client import McpServerSpec
+
+
+def load_host_servers(path: str) -> list[McpServerSpec]:
+    """Parse a host MCP config file into server specs.
+
+    Raises on unreadable/invalid JSON — the caller skips a bad host config so one
+    malformed file never breaks startup.
+    """
+    p = Path(os.path.expandvars(os.path.expanduser(path)))
+    data = json.loads(p.read_text(encoding="utf-8"))
+    servers = data.get("mcpServers", data) if isinstance(data, dict) else {}
+    out: list[McpServerSpec] = []
+    for server_id, cfg in servers.items():
+        if not isinstance(cfg, dict):
+            continue
+        if cfg.get("url"):
+            out.append(McpServerSpec(
+                server_id=server_id, transport="http",
+                url=cfg["url"], headers=cfg.get("headers"),
+            ))
+        elif cfg.get("command"):
+            out.append(McpServerSpec(
+                server_id=server_id, transport="stdio",
+                command=cfg["command"], args=cfg.get("args", []),
+                env=cfg.get("env"), cwd=cfg.get("cwd"),
+            ))
+        # entries with neither url nor command are skipped
+    return out

--- a/tests/kit/test_source_precedence.py
+++ b/tests/kit/test_source_precedence.py
@@ -1,0 +1,70 @@
+"""Toolbox source precedence + drop-with-log collision merge (RFC 0002 §4, 3a)."""
+
+from lackpy.kit.toolbox import ToolSpec, Toolbox
+
+
+class _Src:
+    """Minimal ToolSource: maps tool name -> callable."""
+
+    def __init__(self, name: str, tools: dict):
+        self._name = name
+        self._tools = tools
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def available(self) -> bool:
+        return True
+
+    def discover(self):
+        return [ToolSpec(name=n, provider=self._name) for n in self._tools]
+
+    def resolve(self, spec):
+        return self._tools[spec.name]
+
+
+class _Prov:
+    name = "p"
+
+    def available(self) -> bool:
+        return True
+
+    def resolve(self, spec):
+        return lambda: "registered"
+
+
+def test_higher_precedence_wins_regardless_of_add_order():
+    tb = Toolbox()
+    tb.add_source(_Src("low", {"x": lambda: "low"}), precedence=1)
+    tb.add_source(_Src("high", {"x": lambda: "high"}), precedence=10)
+    assert tb.resolve("x")() == "high"
+
+    tb2 = Toolbox()
+    tb2.add_source(_Src("high", {"x": lambda: "high"}), precedence=10)
+    tb2.add_source(_Src("low", {"x": lambda: "low"}), precedence=1)
+    assert tb2.resolve("x")() == "high"
+
+
+def test_equal_precedence_later_wins():
+    tb = Toolbox()
+    tb.add_source(_Src("a", {"x": lambda: "a"}), precedence=5)
+    tb.add_source(_Src("b", {"x": lambda: "b"}), precedence=5)
+    assert tb.resolve("x")() == "b"
+
+
+def test_shadowed_tool_is_dropped_not_aliased():
+    # v1: no qualified alias — the lower-precedence tool simply isn't reachable.
+    tb = Toolbox()
+    tb.add_source(_Src("high", {"x": lambda: "high"}), precedence=10)
+    tb.add_source(_Src("low", {"x": lambda: "low"}), precedence=1)
+    assert "low__x" not in tb.tools
+    assert set(tb.tools) == {"x"}
+
+
+def test_register_tool_outranks_even_high_precedence_source():
+    tb = Toolbox()
+    tb.register_provider(_Prov())
+    tb.register_tool(ToolSpec(name="x", provider="p"))  # precedence inf
+    tb.add_source(_Src("s", {"x": lambda: "src"}), precedence=999)
+    assert tb.resolve("x")() == "registered"

--- a/tests/sources/test_mcp_host_config.py
+++ b/tests/sources/test_mcp_host_config.py
@@ -1,0 +1,71 @@
+"""Host MCP config ingestion ([mcp].host_configs) — RFC 0002 §3.4, 3b."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+from lackpy.sources.mcp import mcp_available
+
+pytestmark = pytest.mark.skipif(not mcp_available(), reason="mcp SDK not installed")
+
+FIXTURE = str(Path(__file__).parent.parent / "fixtures" / "mcp_echo_server.py")
+
+
+def _host_json(tmp_path: Path) -> Path:
+    cfg = {"mcpServers": {"echo": {"command": sys.executable, "args": [FIXTURE]}}}
+    p = tmp_path / "host.json"
+    p.write_text(json.dumps(cfg))
+    return p
+
+
+def test_load_host_servers_normalizes_mcpservers(tmp_path):
+    from lackpy.sources.mcp.host_config import load_host_servers
+
+    specs = load_host_servers(str(_host_json(tmp_path)))
+    assert len(specs) == 1
+    assert specs[0].server_id == "echo"
+    assert specs[0].transport == "stdio"
+    assert specs[0].command == sys.executable
+    assert specs[0].args == [FIXTURE]
+
+
+def test_load_host_servers_http_entry(tmp_path):
+    from lackpy.sources.mcp.host_config import load_host_servers
+
+    p = tmp_path / "h.json"
+    p.write_text(json.dumps({"mcpServers": {"remote": {"url": "http://localhost:9/mcp"}}}))
+    specs = load_host_servers(str(p))
+    assert specs[0].transport == "http"
+    assert specs[0].url == "http://localhost:9/mcp"
+
+
+async def test_service_ingests_host_config_end_to_end(tmp_path):
+    from lackpy.config import LackpyConfig
+    from lackpy.service import LackpyService
+
+    cfg = LackpyConfig(mcp_host_configs=[str(_host_json(tmp_path))])
+    svc = LackpyService(workspace=tmp_path, config=cfg)
+    try:
+        names = {t["name"] for t in svc.toolbox_list()}
+        assert {"echo", "add"} <= names
+        res = await svc.run_program("r = echo(text='hi')\nr", kit=["echo"])
+        assert res.success, res.error
+        assert res.output == "hi"
+    finally:
+        svc.close()
+
+
+async def test_malformed_host_config_is_skipped_not_fatal(tmp_path):
+    from lackpy.config import LackpyConfig
+    from lackpy.service import LackpyService
+
+    bad = tmp_path / "bad.json"
+    bad.write_text("{ not valid json")
+    # service init must not raise; builtins still present.
+    svc = LackpyService(workspace=tmp_path, config=LackpyConfig(mcp_host_configs=[str(bad)]))
+    try:
+        assert "read_file" in {t["name"] for t in svc.toolbox_list()}
+    finally:
+        svc.close()


### PR DESCRIPTION
Makes multiple tool sources coexist deterministically and lets lackpy consume a host's MCP server set.

## Precedence + drop-with-log collision merge
- `Toolbox.add_source(source, precedence)`: on a name collision the higher-precedence source keeps the bare name (equal → later-added wins); the shadowed tool is **dropped and logged**. v1 keeps **no** `server__tool` alias — the small models lackpy targets never call qualified names, so that machinery would serve no real path (deferred to a later increment if a workflow needs it). Masking names stay **warn-only**.
- `register_tool` now sets precedence `inf` (always authoritative) + pops ownership — closes the increment-1 stale-state bug class (regression-tested).
- Service precedence (resolves the RFC §4 inconsistency toward "auditable local source wins"): user `[[tools]]` (20) > shipped defaults (10) > own `[mcp_servers]` (5) > host configs (4, descending per file so the earlier file wins).

## Host-config ingestion
- `[mcp].host_configs = [paths]` → `load_host_servers()` normalizes the `{"mcpServers": {...}}` shape (stdio + http) into lower-precedence `McpToolSource`s. **Explicit opt-in only** (these spawn subprocesses lackpy didn't author); a malformed/unreachable host config is skipped, never fatal.

## Verification
- **910 passed, 1 skipped**; new code lint-clean. Tests: precedence determinism (order-independent, tie→later, shadow dropped, `register_tool` outranks a high-precedence source); host ingestion end-to-end against the fastmcp fixture + malformed-config-skipped.
- RFC §4 rewritten (precedence order + v1 drop-with-log); status → increments 1–3 implemented.

## Not in scope (RFC increments 4–5)
Virtual/harness tools; the kits→profile layer that retires "kit".

🤖 Generated with [Claude Code](https://claude.com/claude-code)