### PR TITLE
feat: virtual / harness-provided tools (RFC 0002 increment 4)

### DIFF
--- a/docs/concepts/kits.md
+++ b/docs/concepts/kits.md
@@ -105,8 +105,17 @@ grade = { w = 1, d = 0 }
 MCP I/O runs on a dedicated client loop; an MCP-backed tool call from a (synchronous)
 lackpy program is bridged to that loop without blocking generation. A server that
 fails to connect is skipped (its tools simply don't appear), never breaking the
-others. Multi-server namespacing, host-config ingestion, and virtual/harness tools
-are planned — see [Tool Sources (RFC 0002)](../design/tool-sources.md).
+others. Multiple servers and external host configs (`[mcp].host_configs`) merge by
+precedence — local config/builtins win the bare name, then own `[mcp_servers]`, then
+host configs; a shadowed tool is dropped.
+
+### Virtual / harness-provided tools
+
+A host embedding lackpy can pass a `harness_resolver` (`name -> callable | None`) and
+declare tools under `[[virtual_tools]]` (full spec, no implementation). These resolve
+to the harness's callable at run time. Tools the harness can't currently supply are
+hidden from generation; if one is withdrawn between generation and the call, the call
+fails cleanly. See [Tool Sources (RFC 0002)](../design/tool-sources.md).
 
 ---
 

--- a/docs/design/tool-sources.md
+++ b/docs/design/tool-sources.md
@@ -1,9 +1,9 @@
 # RFC 0002 — Tool sources (config, MCP, virtual) & the sync↔async bridge
 
 !!! note "Status"
-    Increments 1–3 are **implemented** (config-defined source; async bridge + MCP
-    client; multi-source precedence + host-config ingestion). Increments 4–5
-    (virtual tools, kits→profile) are **design-only** here. Siblings:
+    Increments 1–4 are **implemented** (config-defined source; async bridge + MCP
+    client; multi-source precedence + host-config ingestion; virtual/harness tools).
+    Increment 5 (kits→profile) is **design-only** here. Siblings:
     [Direction](direction.md), [Interpreter Types](interpreter-types.md), RFC 0001
     (the `lackpy-lang` leaf split).
 
@@ -201,7 +201,15 @@ wins**. Do not mix partial MCP annotation defaults with the mapping — any miss
 ⇒ conservative. Derived grades land on the `ToolSpec` and feed `compute_grade` →
 `ResolvedKit.grade` → `KitPolicySource` → kibitzer with **zero downstream change**.
 
-## 7. Virtual / harness-provided tools (deferred)
+## 7. Virtual / harness-provided tools (implemented)
+
+Implemented as `sources/virtual.py:VirtualToolSource` + the service's
+`harness_resolver` (a `name -> callable | None`) and `_gate_kit`. Declared via
+`[[virtual_tools]]` (full spec; no module). Two-layer enforcement: `_gate_kit`
+drops currently-unavailable virtual tools from the kit before generation, and the
+resolve-time proxy raises if the harness withdrew the tool by call time (→ failed
+ExecutionResult). v1 harness callables are sync (wrap via §5 if async later).
+Precedence sits below local config/builtins, above MCP.
 
 A virtual tool is **fully declared** (`[virtual_tools.<name>]` with full spec) but its
 implementation is supplied by the harness/host at call time and may be absent. The
@@ -241,7 +249,7 @@ kibitzer chain is unchanged; new sources plug in by populating grades correctly.
 3. **Multi/host config + namespacing** — *implemented*. Precedence + drop-with-log
    collision merge in `Toolbox` (§4); `[mcp].host_configs` ingestion of external
    `mcpServers` files at descending precedence (§3.4).
-4. **Virtual/harness tools** (§7).
+4. **Virtual/harness tools** — *implemented* (§7).
 5. **kits→profile layer** on top of sources, retiring "kit" ([direction.md](direction.md) §2).
 
 Throughout: keep `tests/lang/test_no_upward_deps.py` green.

--- a/src/lackpy/config.py
+++ b/src/lackpy/config.py
@@ -29,6 +29,7 @@ class LackpyConfig:
     tools: list[dict[str, Any]] = field(default_factory=list)
     mcp_servers: dict[str, dict[str, Any]] = field(default_factory=dict)
     mcp_host_configs: list[str] = field(default_factory=list)
+    virtual_tools: list[dict[str, Any]] = field(default_factory=list)
     config_dir: Path = field(default_factory=lambda: Path(".lackpy"))
 
 
@@ -48,6 +49,7 @@ def load_config(workspace: Path | None = None) -> LackpyConfig:
     tools = data.get("tools", [])
     mcp_servers = data.get("mcp_servers", {})
     mcp_host_configs = data.get("mcp", {}).get("host_configs", [])
+    virtual_tools = data.get("virtual_tools", [])
     providers: dict[str, dict[str, Any]] = {}
     for name, cfg in inference.get("providers", {}).items():
         providers[name] = cfg
@@ -63,5 +65,6 @@ def load_config(workspace: Path | None = None) -> LackpyConfig:
         tools=tools,
         mcp_servers=mcp_servers,
         mcp_host_configs=mcp_host_configs,
+        virtual_tools=virtual_tools,
         config_dir=config_dir,
     )

--- a/src/lackpy/service.py
+++ b/src/lackpy/service.py
@@ -79,9 +79,12 @@ class LackpyService:
         config: Override configuration. Loaded from .lackpy/config.toml if not provided.
     """
 
-    def __init__(self, workspace: Path | None = None, config: LackpyConfig | None = None) -> None:
+    def __init__(self, workspace: Path | None = None, config: LackpyConfig | None = None,
+                 harness_resolver: Any = None) -> None:
         self._workspace = workspace or Path.cwd()
         self._config = config or load_config(self._workspace)
+        # Optional host/harness resolver for virtual tools: name -> callable | None.
+        self._harness_resolver = harness_resolver
         self._runner = RestrictedRunner()
         # Single-flight execution: serializes the process-global os.chdir in
         # _execute so concurrent delegations can't race on cwd once an execution
@@ -110,6 +113,7 @@ class LackpyService:
     # Source precedences (higher wins the bare name on collision; see Toolbox).
     _PREC_CONFIG = 20    # user [[tools]]
     _PREC_DEFAULT = 10   # shipped builtins
+    _PREC_VIRTUAL = 7    # [[virtual_tools]] (declared locally, harness-implemented)
     _PREC_OWN_MCP = 5    # own [mcp_servers]
     _PREC_HOST_MCP = 4   # host configs (earlier file higher; floors at 1)
 
@@ -127,6 +131,10 @@ class LackpyService:
         ]
         if self._config.tools:
             sources.append((ConfigToolSource(self._config.tools, name="config"), self._PREC_CONFIG))
+        if self._config.virtual_tools:
+            from .sources.virtual import VirtualToolSource
+            sources.append((VirtualToolSource(self._config.virtual_tools, self._harness_resolver),
+                            self._PREC_VIRTUAL))
         sources.extend(self._build_mcp_sources())
         return sources
 
@@ -268,6 +276,32 @@ class LackpyService:
         kits_dir = self._config.config_dir / "kits"
         return resolve_kit(kit, self.toolbox, kits_dir=kits_dir, extra_tools=extra_tools)
 
+    def _gate_kit(self, resolved: ResolvedKit) -> ResolvedKit:
+        """Generation gate: drop virtual tools the harness can't currently supply.
+
+        Keeps the model from composing against an absent tool. (The call-time
+        proxy still raises if a tool is withdrawn between generation and call.)
+        Non-virtual tools are never gated.
+        """
+        drop = {
+            n for n, s in resolved.tools.items()
+            if s.provider == "virtual"
+            and (self._harness_resolver is None or self._harness_resolver(n) is None)
+        }
+        if not drop:
+            return resolved
+        from .lang.grader import compute_grade
+        tools = {n: s for n, s in resolved.tools.items() if n not in drop}
+        callables = {n: c for n, c in resolved.callables.items() if n not in drop}
+        grade = compute_grade(
+            {n: {"grade_w": s.grade_w, "effects_ceiling": s.effects_ceiling} for n, s in tools.items()}
+        )
+        return ResolvedKit(
+            tools=tools, callables=callables, grade=grade,
+            description=self.toolbox.format_description(list(tools.keys())),
+            docs=resolved.docs,
+        )
+
     def _resolve_params(self, params: dict[str, Any] | None, kit: ResolvedKit) -> tuple[dict[str, Any], str | None, set[str]]:
         if not params:
             return {}, None, set()
@@ -329,7 +363,7 @@ class LackpyService:
         from .infer.strategy import STRATEGIES
         from .infer.context import StepContext
 
-        resolved = self._resolve_kit(kit, extra_tools=extra_tools)
+        resolved = self._gate_kit(self._resolve_kit(kit, extra_tools=extra_tools))
         _, params_desc, param_names = self._resolve_params(params, resolved)
 
         effective_mode = mode or self._config.inference_mode
@@ -455,7 +489,7 @@ class LackpyService:
         Returns:
             An ExecutionResult with output, trace, and success status.
         """
-        resolved = self._resolve_kit(kit, extra_tools=extra_tools)
+        resolved = self._gate_kit(self._resolve_kit(kit, extra_tools=extra_tools))
         param_values, _, param_names = self._resolve_params(params, resolved)
         allowed = set(resolved.tools.keys()) | param_names
         validation = validate(program, allowed_names=allowed, extra_rules=rules)
@@ -494,7 +528,7 @@ class LackpyService:
             RuntimeError: If all inference providers fail to produce a valid program.
         """
         start = time.perf_counter()
-        resolved = self._resolve_kit(kit, extra_tools=extra_tools)
+        resolved = self._gate_kit(self._resolve_kit(kit, extra_tools=extra_tools))
         param_values, params_desc, param_names = self._resolve_params(params, resolved)
 
         # Kibitzer: register context for this delegation

--- a/src/lackpy/sources/virtual.py
+++ b/src/lackpy/sources/virtual.py
@@ -1,0 +1,87 @@
+"""Virtual / harness-provided tool source (RFC 0002 §7).
+
+A virtual tool is *fully declared* in config (name, args, returns, grade) but its
+implementation is supplied by the host/harness at call time via a resolver, and
+may or may not be available. Enforcement is two-layered (see LackpyService):
+
+- generation-time visibility gate: unavailable virtual tools are filtered out of
+  the kit before inference, so the model never composes against an absent tool;
+- call-time raise: if a tool was visible at generation but the harness withdrew it
+  before the call, the proxy raises (→ failed ExecutionResult via make_traced).
+"""
+
+from __future__ import annotations
+
+import inspect
+from typing import Any, Callable
+
+from ..kit.toolbox import ArgSpec, ToolSpec
+
+# A harness resolver maps a tool name to its current implementation, or None if
+# the harness does not currently offer it.
+HarnessResolver = Callable[[str], Callable[..., Any] | None]
+
+
+class VirtualToolSource:
+    """Declares harness-provided tools; resolution defers to a harness resolver."""
+
+    def __init__(self, tool_defs: list[dict[str, Any]] | None,
+                 resolver: HarnessResolver | None, name: str = "virtual") -> None:
+        self._name = name
+        self._tool_defs = tool_defs or []
+        self._resolver = resolver
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def available(self) -> bool:
+        # Source-level: contribute the declared specs whenever any are configured.
+        # Per-tool availability is enforced by the gate + the call-time proxy.
+        return bool(self._tool_defs)
+
+    def discover(self) -> list[ToolSpec]:
+        return [self._spec_from_dict(d) for d in self._tool_defs]
+
+    def is_available(self, name: str) -> bool:
+        """Whether the harness currently offers ``name`` (used by the gate)."""
+        return self._resolver is not None and self._resolver(name) is not None
+
+    def resolve(self, spec: ToolSpec) -> Callable[..., Any]:
+        resolver = self._resolver
+        name = spec.name
+        param_names = [a.name for a in spec.args]
+
+        def proxy(*args: Any, **kwargs: Any) -> Any:
+            fn = resolver(name) if resolver is not None else None
+            if fn is None:
+                raise RuntimeError(f"virtual tool {name!r} is unavailable")
+            call_args = dict(zip(param_names, args))
+            call_args.update(kwargs)
+            return fn(**call_args)
+
+        proxy.__signature__ = inspect.Signature(
+            [inspect.Parameter(n, inspect.Parameter.POSITIONAL_OR_KEYWORD) for n in param_names]
+        )
+        proxy.__name__ = name
+        return proxy
+
+    @staticmethod
+    def _spec_from_dict(d: dict[str, Any]) -> ToolSpec:
+        name = d.get("name")
+        if not name:
+            raise ValueError(f"Virtual tool definition missing 'name': {d!r}")
+        args = [
+            ArgSpec(name=a["name"], type=a.get("type", "Any"), description=a.get("description", ""))
+            for a in d.get("args", [])
+        ]
+        return ToolSpec(
+            name=name,
+            provider="virtual",
+            description=d.get("description", ""),
+            args=args,
+            returns=d.get("returns", "Any"),
+            grade_w=d.get("grade_w", 3),
+            effects_ceiling=d.get("effects_ceiling", 3),
+            docs=d.get("docs"),
+        )

--- a/tests/sources/test_virtual.py
+++ b/tests/sources/test_virtual.py
@@ -1,0 +1,67 @@
+"""Virtual / harness-provided tools (RFC 0002 §7, increment 4)."""
+
+from lackpy.config import LackpyConfig
+from lackpy.service import LackpyService
+
+VT = [{
+    "name": "ping",
+    "description": "harness ping",
+    "returns": "str",
+    "grade_w": 2,
+    "effects_ceiling": 2,
+}]
+
+
+def _svc(tmp_path, resolver):
+    return LackpyService(
+        workspace=tmp_path,
+        config=LackpyConfig(virtual_tools=VT),
+        harness_resolver=resolver,
+    )
+
+
+def test_discover_sets_virtual_provider_and_grade():
+    from lackpy.sources.virtual import VirtualToolSource
+
+    spec = VirtualToolSource(VT, lambda n: None).discover()[0]
+    assert spec.provider == "virtual"
+    assert (spec.grade_w, spec.effects_ceiling) == (2, 2)
+
+
+async def test_virtual_tool_runs_when_harness_offers_it(tmp_path):
+    svc = _svc(tmp_path, lambda n: (lambda: "pong") if n == "ping" else None)
+    assert "ping" in {t["name"] for t in svc.toolbox_list()}  # declared/registered
+    res = await svc.run_program("p = ping()\np", kit=["ping"])
+    assert res.success, res.error
+    assert res.output == "pong"
+
+
+async def test_gate_hides_unavailable_virtual_tool(tmp_path):
+    # Resolver never offers it -> gated out of the kit -> program fails validation.
+    svc = _svc(tmp_path, lambda n: None)
+    res = await svc.run_program("p = ping()\np", kit=["ping"])
+    assert not res.success
+    assert "Validation failed" in (res.error or "")
+
+
+async def test_no_resolver_gates_all_virtual_tools(tmp_path):
+    svc = _svc(tmp_path, None)
+    res = await svc.run_program("p = ping()\np", kit=["ping"])
+    assert not res.success
+    assert "Validation failed" in (res.error or "")
+
+
+async def test_call_time_withdrawal_raises_into_failed_result(tmp_path):
+    # Available at the gate (call 1), withdrawn by the time the proxy calls (call 2).
+    calls = {"n": 0}
+
+    def resolver(name):
+        if name != "ping":
+            return None
+        calls["n"] += 1
+        return (lambda: "pong") if calls["n"] == 1 else None
+
+    svc = _svc(tmp_path, resolver)
+    res = await svc.run_program("p = ping()\np", kit=["ping"])
+    assert not res.success
+    assert "unavailable" in (res.error or "")


### PR DESCRIPTION
A host embedding lackpy can declare tools it implements at run time.

- `sources/virtual.py:VirtualToolSource` — `[[virtual_tools]]` declares full specs (no implementation); resolution defers to a `harness_resolver` (`name -> callable | None`) passed to `LackpyService`. Sync proxy raises if the tool is unavailable.
- **Two-layer enforcement (RFC §7):** `_gate_kit` drops currently-unavailable virtual tools from the kit before generation/execution (the model never composes against an absent tool); the call-time proxy raises if the harness withdrew the tool between generation and the call → failed `ExecutionResult`. Non-virtual tools are never gated; the gate is a no-op when nothing is dropped.
- Precedence 7 (below local config/builtins, above MCP). `[[virtual_tools]]` config parsing.

## Verification
- **915 passed, 1 skipped**; new code lint-clean. Tests: discover sets provider/grade; runs when offered; gated (validation fails) when unavailable / no resolver; call-time withdrawal → failed result.
- RFC §7 + status → increments 1–4 implemented; concept-doc note.

## Remaining
Increment 5 — the kits→profile layer that retires "kit".

🤖 Generated with [Claude Code](https://claude.com/claude-code)