### PR TITLE
chore: blq init + project CLAUDE.md (worktrees and sub-agents)

### DIFF
--- a/.bird/commands.toml
+++ b/.bird/commands.toml
@@ -1,0 +1,12 @@
+[commands.test]
+cmd = "python -m pytest tests/ -q"
+description = "Run the full pytest suite"
+format = "pytest_text"
+lines = "+25-"
+sandbox = "none"
+
+[commands.lint]
+cmd = "ruff check src tests"
+description = "Lint source and tests with ruff"
+format = "generic_lint"
+sandbox = "none"

--- a/.bird/config.toml
+++ b/.bird/config.toml
@@ -1,0 +1,34 @@
+capture_env = [
+    "PATH",
+    "HOME",
+    "USER",
+    "SHELL",
+    "PYTHONPATH",
+    "VIRTUAL_ENV",
+    "CONDA_DEFAULT_ENV",
+    "CONDA_PREFIX",
+    "CC",
+    "CXX",
+    "CFLAGS",
+    "CXXFLAGS",
+    "LDFLAGS",
+    "LD_LIBRARY_PATH",
+    "MAKEFLAGS",
+    "CMAKE_PREFIX_PATH",
+    "NODE_PATH",
+    "NPM_CONFIG_PREFIX",
+    "CARGO_HOME",
+    "RUSTUP_HOME",
+    "GOPATH",
+    "GOROOT",
+    "JAVA_HOME",
+    "CLASSPATH",
+    "CI",
+    "GITHUB_ACTIONS",
+    "GITLAB_CI",
+    "JENKINS_URL",
+]
+
+[project]
+namespace = "github__teaguesterling"
+project = "lackpy"

--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,12 @@ results/prompt-eval-dry-run/
 
 # local per-machine workspace config (model choice is a local decision)
 .lackpy/config.toml
+
+# blq — local state ignored; shared command registry tracked
+.bird/*
+!.bird/hooks/
+!.bird/config.toml
+!.bird/commands.toml
+# blq also generates these agent-facing files; keep them local (not committed)
+/.mcp.json
+/CLAUDE.md

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,6 @@ results/prompt-eval-dry-run/
 !.bird/hooks/
 !.bird/config.toml
 !.bird/commands.toml
-# blq also generates these agent-facing files; keep them local (not committed)
+# blq generates a local MCP config; keep it local (don't force the blq server on
+# everyone). CLAUDE.md IS committed — it carries the project's agent guidance.
 /.mcp.json
-/CLAUDE.md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,33 @@
+<!-- blq:agent-instructions -->
+## blq - Build Log Query
+
+Run builds and tests via blq MCP tools, not via Bash directly:
+- `mcp__blq_mcp__commands` - list available commands
+- `mcp__blq_mcp__run` - run a registered command (e.g., `run(command="test")`)
+- `mcp__blq_mcp__register_command` - register new commands
+- `mcp__blq_mcp__status` - check current build/test status
+- `mcp__blq_mcp__events` - filter events; pass `severity="error"` for errors-only (replaces the non-existent `errors` tool)
+- `mcp__blq_mcp__info` - detailed run info (supports relative refs like `+1`, `latest`)
+- `mcp__blq_mcp__output` - search/filter captured logs (grep, tail, head, lines)
+
+Do NOT use shell pipes or redirects in commands (e.g., `pytest | tail -20`).
+Instead: run the command, then use `output(run_id=N, tail=20)` to filter.
+<!-- /blq:agent-instructions -->
+
+## Worktrees & sub-agents
+
+lackpy is a **flat monorepo** (`packages/lackpy-lang` is a sibling distribution, not a
+git submodule). For isolated or parallel work — and **especially when fanning out
+sub-agents that *edit* the repo** — give each its own git worktree rather than sharing
+one working tree. Concurrent edits in a shared tree entangle (uncommitted changes get
+swept into the wrong commit) and churn the index. (Read-only/Explore sub-agents don't
+need this — only parallel *mutating* ones do.)
+
+- Ephemeral fan-out: spawn the sub-agent with the Agent tool's `isolation: "worktree"`.
+- Persistent/human worktrees: use `git-wt` (see the global worktree guidance).
+
+When using `git-wt` on lackpy, share `.lackpy/` (config, kits, templates — read-mostly)
+from `main/` across worktrees via `.git-worktree-shared`. Do **not** blanket-share
+`.bird/` (blq's DuckDB) when parallel sub-agents run builds — DuckDB is single-writer,
+so a shared DB invites lock contention; one history is only worth it for serial work.
+Never share source or `packages/` — those must diverge per branch.


### PR DESCRIPTION
Two pieces of agent-config setup for lackpy.

blq init: routes build/test/lint through blq (test=pytest, lint=ruff); tracks the shared command registry, keeps .bird/ state and the generated .mcp.json local.

Project CLAUDE.md: reverses the gitignore-CLAUDE.md decision so lackpy carries committed agent guidance (.mcp.json stays local). Adds a Worktrees and sub-agents section: prefer an isolated worktree for parallel work and especially fan-out sub-agents that edit the repo (Agent tool isolation worktree, or git-wt); read-only sub-agents do not need it. lackpy-specific: share .lackpy across worktrees, do not blanket-share .bird (DuckDB single-writer) under parallel runs, never share source/packages. Also fixes the blq block reference to the non-existent errors tool to events.