### PR TITLE
fix: out-of-the-box delegate fixes (print capture, actionable error) + CLI docs alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
 ## What it does
 
 ```bash
-$ lackpy delegate "read file main.py and count its lines" --kit read_file,find_files
+$ lackpy -c "read file main.py and count its lines" --kit read_file,find_files
 ```
 
-lackpy takes an intent, generates a restricted Python program using a local 1.5B model, validates it against a strict AST whitelist, and runs it with traced tool calls. One MCP call replaces N tool round-trips.
+lackpy takes an intent, generates a restricted Python program using a local model you configure (any Ollama-served coder model), validates it against a strict AST whitelist, and runs it with traced tool calls. One MCP call replaces N tool round-trips.
 
 ## Install
 
@@ -42,9 +42,13 @@ pip install -e ./packages/lackpy-lang -e ".[dev]"
 ## Quick start
 
 ```bash
-lackpy init --ollama-url http://localhost:11434
-lackpy delegate "find all python files" --kit read_file,find_files
+lackpyctl init --ollama-url http://localhost:11434   # writes .lackpy/config.toml
+lackpy -c "find all python files" --kit read_file,find_files
 ```
+
+`lackpyctl init` wires a local Ollama model into the inference order — pick the model
+with `--ollama-model` (the choice is per-machine, not a package default). Without it,
+only the deterministic templates/rules tiers run and compositional intents won't generate.
 
 ```python
 from lackpy.service import LackpyService

--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -46,7 +46,7 @@ Validation is also performed inside `InferenceDispatcher` after each provider at
 | `lackpy.lang.validator` | AST walk + rule application → `ValidationResult` | `lang.grammar` |
 | `lackpy.lang.grader` | `Grade(w, d)` computation from tool specs | none |
 | `lackpy.lang.rules` | Built-in custom rule callables | `ast` |
-| `lackpy.lang.spec` | Machine-readable grammar spec (used by `lackpy spec`) | `lang.grammar` |
+| `lackpy.lang.spec` | Machine-readable grammar spec (used by `lackpyctl spec`) | `lang.grammar` |
 | `lackpy.kit.toolbox` | `Toolbox` — provider registry + tool resolution | none |
 | `lackpy.kit.registry` | `resolve_kit()` — name/list/dict → `ResolvedKit` | `kit.toolbox`, `lang.grader` |
 | `lackpy.kit.providers.builtin` | Built-in tools: `read_file`, `find_files`, `write_file`, `edit_file` | `pathlib` |

--- a/docs/concepts/inference.md
+++ b/docs/concepts/inference.md
@@ -128,26 +128,39 @@ The `order` list controls priority. Built-in providers (`templates`, `rules`) ar
 
 The ratchet pattern is a workflow built on top of the template tier:
 
-1. Issue `delegate` — the intent is handled by rules or an LLM on the first call.
+1. Delegate an intent (`lackpy -c "..."`) — handled by rules or an LLM on the first call.
 2. Verify the result is correct.
-3. Issue `create` to save the validated program as a template with an intent pattern.
-4. Subsequent `delegate` calls with matching intents hit tier 0 — zero latency, guaranteed valid.
+3. Save the validated program as a **`.tmpl` template** with an intent `pattern:`.
+4. Subsequent delegates with matching intents hit tier 0 — zero latency, guaranteed valid.
 
 Over time, the template library grows and LLM calls become less frequent. The template tier acts as a ratchet: once an intent is captured, it stays captured.
 
 ```bash
-# Step 1: first run (rules tier)
-lackpy delegate "read the file pyproject.toml" --kit read_file
+# Step 1: first run (rules or LLM tier)
+lackpy -c "read the file pyproject.toml" --kit read_file
+```
 
-# Step 2: save as template
-cat > read_pyproject.py << 'EOF'
-content = read_file('pyproject.toml')
-content
-EOF
-lackpy create read_pyproject.py --name read-pyproject --kit read_file
+```python
+# Step 2: capture it as a pattern-matched template (Python API).
+# The CLI's `--create` flag saves a run-by-path *Lackey file* instead — that's a
+# separate reuse mechanism and is NOT matched against future intents. Only `.tmpl`
+# files with a `pattern:` populate the tier-0 templates cache, and today the only
+# way to write one (other than authoring it by hand) is svc.create(pattern=...).
+import asyncio
+from lackpy.service import LackpyService
 
+svc = LackpyService()
+asyncio.run(svc.create(
+    program="content = read_file('pyproject.toml')\ncontent",
+    name="read-pyproject",
+    pattern="read the file pyproject.toml",
+    kit=["read_file"],
+))
+```
+
+```bash
 # Step 3: future runs hit tier 0
-lackpy delegate "read the file pyproject.toml" --kit read_file
+lackpy -c "read the file pyproject.toml" --kit read_file
 # generation_tier: "templates"
 ```
 

--- a/docs/concepts/interpreters.md
+++ b/docs/concepts/interpreters.md
@@ -9,7 +9,7 @@ string, validates it, and executes it against an
 !!! note "Library-only in v0.5.x"
 
     The interpreter plugin system is currently a **library API**, not yet
-    plumbed through `LackpyService.delegate()` or the `lackpy delegate`
+    plumbed through `LackpyService.delegate()` or the `lackpy -c`
     CLI. To use any non-default interpreter, import it and call
     `run_interpreter()` directly (see the examples below). CLI and service
     integration is planned for a future release — when it lands, the

--- a/docs/concepts/kits.md
+++ b/docs/concepts/kits.md
@@ -203,16 +203,16 @@ The `docs` path is relative to the workspace root. It is not loaded at resolutio
 
 ```bash
 # List all kits in .lackpy/kits/
-lackpy kit list
+lackpyctl kit list
 
 # Show tools and grade for a kit
-lackpy kit info filesystem
+lackpyctl kit info filesystem
 
 # Show tools and grade for an ad-hoc list
-lackpy kit info read_file,find_files,write_file
+lackpyctl kit info read_file,find_files,write_file
 
 # Create a new kit
-lackpy kit create mykit --tools read_file find_files --description "Read-only tools"
+lackpyctl kit create mykit --tools read_file find_files --description "Read-only tools"
 ```
 
 ---

--- a/docs/concepts/language-spec.md
+++ b/docs/concepts/language-spec.md
@@ -149,7 +149,7 @@ This prevents `__` strings from being used as arguments to reflection functions,
 The current grammar is also available as JSON:
 
 ```bash
-lackpy spec
+lackpyctl spec
 ```
 
 ```json

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -10,7 +10,7 @@
     pip install lackpy
     ```
 
-    With the base install you can validate and run programs, manage kits and templates, and use the full Python API — but inference (`delegate`, `generate`) will only work via the built-in `templates` and `rules` tiers.
+    With the base install you can validate and run programs, manage kits and templates, and use the full Python API — but inference (delegate and `--generate`) will only work via the built-in `templates` and `rules` tiers. Compositional intents won't generate until you configure a local Ollama model with `lackpyctl init --ollama-model`.
 
 === "With Ollama"
 
@@ -20,7 +20,7 @@
     pip install "lackpy[ollama]"
     ```
 
-    Then pull a model:
+    Then pull whatever model your Ollama host serves best — the choice is per-machine, not a package default:
 
     ```bash
     ollama pull qwen2.5-coder:1.5b
@@ -56,11 +56,11 @@ Python 3.11+ ships `tomllib` in the standard library; `tomli` is only needed on 
 
 ## Initialize a workspace
 
-lackpy stores configuration, kits, and templates under `.lackpy/` in your workspace directory. Create this structure with:
+lackpy stores configuration, kits, and templates under `.lackpy/` in your workspace directory. Create this structure with `lackpyctl`:
 
 ```bash
 cd my-project
-lackpy init
+lackpyctl init
 ```
 
 This creates:
@@ -72,10 +72,10 @@ This creates:
   templates/        # .tmpl files for the ratchet pattern
 ```
 
-To configure a specific Ollama model at init time:
+The inference order wires in a local Ollama provider so compositional intents work once a model is served. The model choice is **per-machine** — configure it at init time:
 
 ```bash
-lackpy init --ollama-model codellama:7b
+lackpyctl init --ollama-model codellama:7b
 ```
 
 ### Config file
@@ -109,13 +109,13 @@ See [Concepts: Inference Pipeline](concepts/inference.md) for all config options
 Check what tools are available:
 
 ```bash
-lackpy toolbox list
+lackpyctl toolbox list
 ```
 
-Generate and run a program:
+Generate and run a program (delegate is the default `lackpy -c` mode):
 
 ```bash
-lackpy delegate "read the file README.md" --kit read_file
+lackpy -c "read the file README.md" --kit read_file
 ```
 
 The output is JSON with the generated program, trace, and result:
@@ -133,9 +133,13 @@ The output is JSON with the generated program, trace, and result:
     {"step": 0, "tool": "read_file", "args": {"path": "README.md"}, "result": "...", "duration_ms": 1.1, "success": true, "error": null}
   ],
   "output": "# My Project\n...",
+  "stdout": "",
   "error": null
 }
 ```
+
+!!! note "Printed output is captured"
+    When a generated program `print()`s its answer instead of leaving a bare final expression, the printed text is captured in `stdout` and surfaced as `output` (so `print(...)` no longer yields `output: null`).
 
 !!! tip "Check inference tier"
     The `generation_tier` field tells you which provider handled the request: `templates` (tier 0), `rules` (tier 1), `ollama` (tier 2), or `anthropic` (tier 3).

--- a/docs/index.md
+++ b/docs/index.md
@@ -20,18 +20,21 @@ intent → restricted Python → validation → traced execution → result
 
 ## Quick start — CLI
 
+lackpy ships two binaries: `lackpy` (flag-based inference on a single `-c` intent —
+delegate is the default mode) and `lackpyctl` (workspace management).
+
 ```bash
 # Initialize a workspace
-lackpy init
+lackpyctl init
 
-# Generate and run a program from natural language
-lackpy delegate "read the file README.md" --kit read_file,find_files
+# Generate and run a program from natural language (delegate is the default mode)
+lackpy -c "read the file README.md" --kit read_file,find_files
 
 # Just generate — don't run
-lackpy generate "find all Python files" --kit find_files
+lackpy -c "find all Python files" --generate --kit find_files
 
-# Validate a hand-written program
-lackpy validate my_program.py --kit read_file,find_files
+# Validate a hand-written program file
+lackpy my_program.py --validate --kit read_file,find_files
 ```
 
 ## Quick start — Python API
@@ -58,13 +61,19 @@ asyncio.run(main())
 
 ## Rigged Suite
 
-The "rigged suite" is the property that lackpy's inference pipeline can be made deterministic for any intent that has been seen before. Save a validated program as a template:
+The "rigged suite" is the property that lackpy's inference pipeline can be made deterministic for any intent that has been seen before. There are two complementary mechanisms:
+
+**Lackey files.** Generate a program from an intent and save it as a reusable **Lackey file** (a Python class) under `.lackpy/templates/`, then invoke it by path:
 
 ```bash
-lackpy create my_program.py --name read-file --pattern "read the file {path}" --kit read_file
+lackpy -c "read the file README.md" --create --name ReadFile --kit read_file
+# → Created .lackpy/templates/ReadFile.py
+lackpy .lackpy/templates/ReadFile.py
 ```
 
-On the next `delegate` call with a matching intent, the template tier fires at tier 0 — before any LLM is consulted. The program is guaranteed valid because it was validated when it was saved.
+The saved program is guaranteed valid because it was validated when it was created, and running it by path skips inference entirely.
+
+**Templates.** For intent-driven deterministic matching, save a `.tmpl` template with a `pattern` (via the `svc.create(pattern=...)` Python API). The template tier (tier 0) then matches future intents by pattern and instantiates the stored program — before any LLM is consulted.
 
 ---
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,32 +1,185 @@
 # CLI Reference
 
+lackpy ships **two** command-line entry points:
+
+| Command | Purpose |
+|---------|---------|
+| `lackpy` | Run inference: delegate / generate / validate / create from intent, and run program files. |
+| `lackpyctl` | Manage the workspace: init, status, kits, toolbox, templates, providers, MCP server. |
+
 ```
-lackpy [--workspace PATH] <command> [args]
+lackpy    [--workspace PATH] -c "<intent>" [flags]      # or: lackpy <file> [flags]
+lackpyctl [--workspace PATH] <command> [args]
 ```
 
-All commands accept `--workspace PATH` to set the project root (default: current directory).
+Both accept `--workspace PATH` to set the project root (default: current directory).
+
+> **Note:** `lackpy` is **flag-based**, not subcommand-based. The mode is selected by
+> flags on a single intent (`-c`): the default is *delegate* (generate + run);
+> `--generate`, `--validate`, and `--create` select the other modes.
 
 ---
 
-## `lackpy init`
+# `lackpy` — inference
+
+## delegate (default)
+
+Generate a program from a natural-language intent and run it immediately.
+
+```bash
+lackpy -c "<intent>" [--kit KIT] [--tools TOOLS] [--param k=v ...] [--mode MODE]
+```
+
+**Arguments**
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `-c "<intent>"` | yes | Natural-language description of the task |
+| `--kit` | no | Kit name, comma-separated tool list, or `@file` |
+| `--tools` | no | Extra tool names (comma-separated) to add on top of the kit |
+| `--param` | no | Parameter `key=value` (repeatable) |
+| `--mode` | no | Inference mode: `1-shot`, `spm` (default: from config) |
+
+**Output:** JSON with `success`, `program`, `grade`, `generation_tier`, timing fields,
+`trace`, `output`, `stdout`, and `error`. (`output` falls back to captured `stdout`
+when the generated program `print()`s its answer instead of leaving a bare final
+expression.)
+
+**Exit code:** 0 on success, 1 on failure.
+
+**Examples:**
+
+```bash
+lackpy -c "read the file README.md" --kit read_file
+lackpy -c "find all Python files" --kit read_file,find_files
+```
+
+---
+
+## generate (`--generate`)
+
+Run the inference pipeline and print the generated program **without executing it**.
+
+```bash
+lackpy -c "<intent>" --generate [--kit KIT]
+```
+
+**Output:** The program text (not JSON).
+
+**Exit code:** 0 on success; 1 if generation fails.
+
+**Example:**
+
+```bash
+lackpy -c "find all Python files" --generate --kit find_files
+```
+
+---
+
+## validate (`--validate`)
+
+Validate a program against the AST whitelist without running it. Validate either an
+inline code string (with `-c`) or a file (as a positional argument).
+
+```bash
+lackpy -c "<program source>" --validate [--kit KIT]
+lackpy <file> --validate [--kit KIT]
+```
+
+**Output:** JSON with `valid` (bool), `errors` (list), `calls` (list).
+
+**Exit code:** 0 if valid, 1 if invalid.
+
+**Examples:**
+
+```bash
+lackpy my_program.py --validate --kit read_file
+lackpy -c "read_file('x.py')" --validate --kit read_file
+```
+
+---
+
+## create (`--create`)
+
+Generate a program from an intent and save it as a reusable **Lackey file**
+(a Python class wrapping the program) under `.lackpy/templates/`.
+
+```bash
+lackpy -c "<intent>" --create --name NAME [--kit KIT] [--tools TOOLS]
+```
+
+**Arguments**
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `-c "<intent>"` | yes | Intent to generate the saved program from |
+| `--create` | yes | Select create mode |
+| `--name` | no | Class name for the Lackey file (default: `Generated`) |
+| `--kit` / `--tools` | no | Tools available to the generated program |
+
+**Output:** `Created <path>` (plain text).
+
+**Exit code:** 0 on success.
+
+**Example:**
+
+```bash
+lackpy -c "read the file README.md" --create --name ReadReadme --kit read_file
+```
+
+---
+
+## Running a program file
+
+Pass a file path as the first positional argument. Lackey files (a `Lackey` class with
+a `run` method) are detected and run directly; plain program files need `--kit` or
+`--tools` to supply a namespace.
+
+```bash
+lackpy <file.py> --kit KIT          # run a plain program file
+lackpy <file.py> --tools read_file  # ...with ad-hoc tools
+lackpy my_lackey.py                 # run a Lackey file (tools come from the file)
+```
+
+**Output:** JSON with `success`, `output`, `error`.
+
+**Exit code:** 0 on success, 1 on failure or validation error.
+
+You can also pipe a program on stdin:
+
+```bash
+echo "find_files('*.py')" | lackpy --kit find_files
+```
+
+---
+
+# `lackpyctl` — workspace management
+
+## `lackpyctl init`
 
 Initialize a `.lackpy/` workspace in the current directory.
 
 ```bash
-lackpy init [--ollama-model MODEL]
+lackpyctl init [--ollama-url URL] [--ollama-model MODEL]
 ```
 
 **Arguments**
 
 | Argument | Default | Description |
 |----------|---------|-------------|
-| `--ollama-model` | `qwen2.5-coder:1.5b` | Default Ollama model to write into config |
+| `--ollama-url` | `http://localhost:11434` | Ollama server URL written into config |
+| `--ollama-model` | `qwen2.5-coder:1.5b` | Ollama model written into config |
 
 **Creates:**
 
-- `.lackpy/config.toml` — inference order, kit defaults, sandbox settings
-- `.lackpy/templates/` — directory for `.tmpl` files
+- `.lackpy/config.toml` — inference order (`templates`, `rules`, `ollama-local`), kit
+  default, sandbox settings
+- `.lackpy/templates/` — directory for saved Lackey files / `.tmpl` files
 - `.lackpy/kits/` — directory for `.kit` files
+
+The generated config wires the Ollama provider into the inference order, so
+compositional intents work out of the box once a model is served. The model choice is
+**per-machine** — pick whatever your Ollama host serves best with `--ollama-model`.
 
 If `config.toml` already exists, `init` prints a warning and does nothing.
 
@@ -34,201 +187,58 @@ If `config.toml` already exists, `init` prints a warning and does nothing.
 
 ```bash
 cd my-project
-lackpy init --ollama-model codellama:7b
+lackpyctl init --ollama-url http://localhost:11434 --ollama-model qwen2.5-coder:3b
 ```
 
 ---
 
-## `lackpy delegate`
-
-Generate a program from natural language intent and run it immediately.
-
-```bash
-lackpy delegate <intent> [--kit KIT] [--sandbox PROFILE]
-```
-
-**Arguments**
-
-| Argument | Required | Description |
-|----------|----------|-------------|
-| `intent` | yes | Natural language description of the task |
-| `--kit` | no | Kit name, comma-separated tool list, or `@file` |
-| `--sandbox` | no | Sandbox profile name (v2, not yet active) |
-
-**Output:** JSON with `success`, `program`, `grade`, `generation_tier`, timing fields, `trace`, `output`, and `error`.
-
-**Exit code:** 0 on success, 1 on failure.
-
-**Examples:**
-
-```bash
-lackpy delegate "read the file README.md" --kit read_file
-lackpy delegate "find all Python files" --kit read_file,find_files
-```
-
----
-
-## `lackpy generate`
-
-Run the inference pipeline and print the generated program, without executing it.
-
-```bash
-lackpy generate <intent> [--kit KIT]
-```
-
-**Arguments**
-
-| Argument | Required | Description |
-|----------|----------|-------------|
-| `intent` | yes | Natural language description |
-| `--kit` | no | Kit name or comma-separated tool list |
-
-**Output:** The program text (not JSON).
-
-**Exit code:** Always 0.
-
-**Example:**
-
-```bash
-lackpy generate "find all Python files" --kit find_files
-```
-
----
-
-## `lackpy run`
-
-Validate and run a program from a file.
-
-```bash
-lackpy run <file> [--kit KIT]
-```
-
-**Arguments**
-
-| Argument | Required | Description |
-|----------|----------|-------------|
-| `file` | yes | Path to the program file |
-| `--kit` | no | Kit name or comma-separated tool list |
-
-**Output:** JSON with `success`, `output`, `error`.
-
-**Exit code:** 0 on success, 1 on failure or validation error.
-
-**Example:**
-
-```bash
-lackpy run my_program.py --kit read_file,find_files
-```
-
----
-
-## `lackpy validate`
-
-Validate a program file without running it.
-
-```bash
-lackpy validate <file> [--kit KIT]
-```
-
-**Arguments**
-
-| Argument | Required | Description |
-|----------|----------|-------------|
-| `file` | yes | Path to the program file |
-| `--kit` | no | Kit name or comma-separated tool list |
-
-**Output:** JSON with `valid` (bool), `errors` (list), `calls` (list).
-
-**Exit code:** 0 if valid, 1 if invalid.
-
-**Example:**
-
-```bash
-lackpy validate my_program.py --kit read_file
-```
-
----
-
-## `lackpy create`
-
-Validate a program and save it as a template.
-
-```bash
-lackpy create <file> --name NAME [--kit KIT] [--pattern PATTERN]
-```
-
-**Arguments**
-
-| Argument | Required | Description |
-|----------|----------|-------------|
-| `file` | yes | Path to the program file |
-| `--name` | yes | Template name (used as filename: `{name}.tmpl`) |
-| `--kit` | no | Kit name or comma-separated tool list |
-| `--pattern` | no | Intent pattern with `{placeholder}` variables |
-
-**Output:** JSON with `success`, `path` (or `errors`).
-
-**Exit code:** 0 on success, 1 on validation failure.
-
-**Example:**
-
-```bash
-lackpy create read_file.py --name read-file --pattern "read the file {path}" --kit read_file
-```
-
----
-
-## `lackpy spec`
-
-Print the language grammar as JSON.
-
-```bash
-lackpy spec
-```
-
-**Output:** JSON with `allowed_nodes`, `forbidden_nodes`, `forbidden_names`, `allowed_builtins`.
-
-**Exit code:** Always 0.
-
----
-
-## `lackpy status`
+## `lackpyctl status`
 
 Show the current workspace configuration.
 
 ```bash
-lackpy status
+lackpyctl status
 ```
 
-**Output:** JSON with `workspace`, `config_dir`, `inference_order`, `kit_default`, `sandbox_enabled`, `tools`.
-
-**Exit code:** Always 0.
+**Output:** JSON with `workspace`, `config_dir`, `inference_order`, `kit_default`,
+`sandbox_enabled`, `tools`.
 
 ---
 
-## `lackpy kit`
+## `lackpyctl spec`
+
+Print the language grammar as JSON.
+
+```bash
+lackpyctl spec
+```
+
+**Output:** JSON with `allowed_nodes`, `forbidden_nodes`, `forbidden_names`,
+`allowed_builtins`.
+
+---
+
+## `lackpyctl kit`
 
 Manage kit files.
 
-### `lackpy kit list`
+### `lackpyctl kit list`
 
 List all `.kit` files in `.lackpy/kits/`.
 
 ```bash
-lackpy kit list
+lackpyctl kit list
 ```
 
 **Output:** JSON array of `{name, path}`.
 
-### `lackpy kit info`
+### `lackpyctl kit info`
 
 Show the tools and grade for a kit.
 
 ```bash
-lackpy kit info <name> [--tools TOOL ...]
+lackpyctl kit info <name> [--tools TOOL ...]
 ```
-
-**Arguments**
 
 | Argument | Description |
 |----------|-------------|
@@ -237,15 +247,13 @@ lackpy kit info <name> [--tools TOOL ...]
 
 **Output:** JSON with `tools`, `grade`, `description`.
 
-### `lackpy kit create`
+### `lackpyctl kit create`
 
 Create a new kit file.
 
 ```bash
-lackpy kit create <name> --tools TOOL [TOOL ...] [--description TEXT]
+lackpyctl kit create <name> --tools TOOL [TOOL ...] [--description TEXT]
 ```
-
-**Arguments**
 
 | Argument | Required | Description |
 |----------|----------|-------------|
@@ -253,69 +261,88 @@ lackpy kit create <name> --tools TOOL [TOOL ...] [--description TEXT]
 | `--tools` | yes | One or more tool names |
 | `--description` | no | Human-readable description |
 
-**Output:** JSON with `name`, `path`, `tools`.
-
 **Example:**
 
 ```bash
-lackpy kit create readonly --tools read_file find_files --description "Read-only filesystem tools"
+lackpyctl kit create readonly --tools read_file find_files --description "Read-only filesystem tools"
 ```
 
 ---
 
-## `lackpy toolbox`
+## `lackpyctl toolbox`
 
 Inspect the registered tool catalog.
 
-### `lackpy toolbox list`
+### `lackpyctl toolbox list`
 
 List all registered tools.
 
 ```bash
-lackpy toolbox list
+lackpyctl toolbox list
 ```
 
 **Output:** JSON array of `{name, provider, description, grade_w, effects_ceiling}`.
 
-### `lackpy toolbox show`
+### `lackpyctl toolbox show`
 
 Show details for a single tool.
 
 ```bash
-lackpy toolbox show <name>
+lackpyctl toolbox show <name>
 ```
-
-**Arguments**
-
-| Argument | Description |
-|----------|-------------|
-| `name` | Tool name |
 
 **Output:** JSON object for the tool.
 
 ---
 
-## `lackpy template`
+## `lackpyctl template`
 
 Manage template files.
 
-### `lackpy template list`
+### `lackpyctl template list`
 
 List all `.tmpl` files in `.lackpy/templates/`.
 
 ```bash
-lackpy template list
+lackpyctl template list
 ```
 
 **Output:** JSON array of `{name, path}`.
 
-### `lackpy template test`
+### `lackpyctl template test`
 
 Test a template against an intent (not yet implemented).
 
 ```bash
-lackpy template test <name>
+lackpyctl template test <name>
 ```
+
+---
+
+## `lackpyctl mcp`
+
+Manage the MCP server.
+
+### `lackpyctl mcp serve`
+
+Start the lackpy MCP server over stdio transport.
+
+```bash
+lackpyctl mcp serve
+```
+
+### `lackpyctl mcp init`
+
+Add lackpy to `.mcp.json`.
+
+```bash
+lackpyctl mcp init [--name NAME] [--force]
+```
+
+| Argument | Default | Description |
+|----------|---------|-------------|
+| `--name` | `lackpy` | Server name in `.mcp.json` |
+| `--force` | off | Overwrite an existing entry |
 
 ---
 
@@ -334,7 +361,8 @@ Any command that accepts `--kit` supports these forms:
 
 ## Extra tools (`--tools`)
 
-Any command that accepts `--kit` also accepts `--tools` to add individual tools on top of the kit:
+Any inference invocation that accepts `--kit` also accepts `--tools` to add individual
+tools on top of the kit:
 
 ```bash
 # Add edit_file to a named kit

--- a/docs/tutorial.md
+++ b/docs/tutorial.md
@@ -2,7 +2,7 @@
 
 This walkthrough covers every major feature of lackpy. Follow along in order, or jump to any section.
 
-**Prerequisites:** lackpy installed, workspace initialized with `lackpy init`. See [Getting Started](getting-started.md).
+**Prerequisites:** lackpy installed, workspace initialized with `lackpyctl init`. See [Getting Started](getting-started.md).
 
 ---
 
@@ -13,13 +13,13 @@ Create a project directory and initialize:
 ```bash
 mkdir my-lackpy-project && cd my-lackpy-project
 echo "# Hello from lackpy" > README.md
-lackpy init
+lackpyctl init
 ```
 
 Confirm the setup:
 
 ```bash
-lackpy status
+lackpyctl status
 ```
 
 ```json
@@ -86,7 +86,7 @@ count = len(files)
 count
 EOF
 
-lackpy validate check.py --kit find_files
+lackpy check.py --validate --kit find_files
 ```
 
 ```json
@@ -107,7 +107,7 @@ import sys
 sys.version
 EOF
 
-lackpy validate bad.py --kit find_files
+lackpy bad.py --validate --kit find_files
 ```
 
 ```json
@@ -158,19 +158,19 @@ A **kit** is a named subset of tools from the toolbox. Kits control which functi
 ### List available tools
 
 ```bash
-lackpy toolbox list
+lackpyctl toolbox list
 ```
 
 ### Use a comma-separated kit
 
 ```bash
-lackpy delegate "read the file README.md" --kit read_file,find_files
+lackpy -c "read the file README.md" --kit read_file,find_files
 ```
 
 ### Create a named kit
 
 ```bash
-lackpy kit create filesystem --tools read glob write --description "File system tools"
+lackpyctl kit create filesystem --tools read glob write --description "File system tools"
 ```
 
 This creates `.lackpy/kits/filesystem.kit`:
@@ -188,13 +188,13 @@ write
 ### Use the named kit
 
 ```bash
-lackpy delegate "find all Python files" --kit filesystem
+lackpy -c "find all Python files" --kit filesystem
 ```
 
 ### Kit info
 
 ```bash
-lackpy kit info filesystem
+lackpyctl kit info filesystem
 ```
 
 ```json
@@ -231,10 +231,10 @@ result = await svc.delegate(
 
 ## 5. Generating programs
 
-`generate` runs the inference pipeline without executing the result:
+The `--generate` flag runs the inference pipeline without executing the result:
 
 ```bash
-lackpy generate "find all Python files" --kit find_files
+lackpy -c "find all Python files" --generate --kit find_files
 ```
 
 ```python
@@ -249,7 +249,7 @@ files
     Templates are matched first. If a template pattern matches the intent, the stored program is returned — no LLM required.
 
     ```bash
-    lackpy generate "read the file config.toml" --kit read_file
+    lackpy -c "read the file config.toml" --generate --kit read_file
     # → matched by rules tier: content = read_file('config.toml')
     ```
 
@@ -291,7 +291,7 @@ print(result.generation_time_ms)
 
 ## 6. Running programs directly
 
-Use `run` when you already have a program file:
+When you already have a program file, pass its path as the first positional argument (there is no `run` subcommand). A plain program file needs `--kit` or `--tools` to supply its namespace; a Lackey file carries its own tools and needs neither:
 
 ```bash
 cat > list_py.py << 'EOF'
@@ -299,7 +299,7 @@ files = find_files("**/*.py")
 files
 EOF
 
-lackpy run list_py.py --kit find_files
+lackpy list_py.py --kit find_files
 ```
 
 ```json
@@ -357,23 +357,47 @@ content
 
 ---
 
-## 8. Creating templates (the ratchet)
+## 8. Saving programs for reuse (the ratchet)
 
-Once you have a working program, save it as a template to make future matching deterministic:
+lackpy gives you two ways to reuse a validated program. They're distinct mechanisms:
+
+### Lackey files (saved program, run by path)
+
+The `--create` flag generates a program from your intent and saves it as a **Lackey file** — a Python class wrapping the program, plus its tools — under `.lackpy/templates/`:
 
 ```bash
-cat > read_file.py << 'EOF'
-content = read_file('{path}')
-content
-EOF
-
-lackpy create read_file.py \
-  --name read-file \
-  --pattern "read the file {path}" \
-  --kit read_file
+lackpy -c "read the file README.md" --create --name ReadFile --kit read_file
 ```
 
-This creates `.lackpy/templates/read-file.tmpl`:
+The output is plain text:
+
+```
+Created .lackpy/templates/ReadFile.py
+```
+
+A Lackey file carries its own tools and a validated program. You run it by path — this skips inference entirely:
+
+```bash
+lackpy .lackpy/templates/ReadFile.py
+```
+
+A Lackey file is **not** matched against future intents; it's a saved program you invoke directly.
+
+### Templates (pattern-matched at tier 0)
+
+To make *intent matching* deterministic, save a `.tmpl` template with a `pattern`. This is exposed through the Python API (`svc.create`), which writes a `.tmpl` file with frontmatter:
+
+```python
+result = await svc.create(
+    program="content = read_file('{path}')\ncontent",
+    kit=["read_file"],
+    name="read-file",
+    pattern="read the file {path}",
+)
+print(result["path"])  # .lackpy/templates/read-file.tmpl
+```
+
+This writes `.lackpy/templates/read-file.tmpl`:
 
 ```
 ---
@@ -386,19 +410,7 @@ content = read_file('{path}')
 content
 ```
 
-Now `lackpy delegate "read the file README.md"` matches at tier 0, with `{path}` substituted to `README.md`. No LLM is called.
-
-### Python API
-
-```python
-result = await svc.create(
-    program="content = read_file('{path}')\ncontent",
-    kit=["read_file"],
-    name="read-file",
-    pattern="read the file {path}",
-)
-print(result["path"])  # .lackpy/templates/read-file.tmpl
-```
+Now a delegate call (the default `lackpy -c` mode) for `"read the file README.md"` matches the template at tier 0, with `{path}` substituted to `README.md`. No LLM is called.
 
 ---
 

--- a/src/lackpy/cli.py
+++ b/src/lackpy/cli.py
@@ -72,7 +72,8 @@ async def _run_file(svc: Any, path: Path, kit: list[str] | None, params: dict[st
         return await svc.run_lackey(path, params=params, sandbox=sandbox)
     elif kit or extra_tools:
         exec_result = await svc.run_program(content, kit=kit, params=params, extra_tools=extra_tools)
-        return {"success": exec_result.success, "output": exec_result.output, "error": exec_result.error}
+        return {"success": exec_result.success, "output": exec_result.effective_output,
+                "stdout": exec_result.stdout, "error": exec_result.error}
     else:
         return {"success": False, "error": "Specify --kit or --tools for plain program files, or use a Lackey file."}
 
@@ -193,7 +194,8 @@ def main(argv: list[str] | None = None) -> int:
             svc = LackpyService(workspace=workspace)
             kit = _parse_kit(args.kit) if args.kit else None
             exec_result = asyncio.run(svc.run_program(program, kit=kit, extra_tools=extra_tools))
-            out_dict = {"success": exec_result.success, "output": exec_result.output, "error": exec_result.error}
+            out_dict = {"success": exec_result.success, "output": exec_result.effective_output,
+                        "stdout": exec_result.stdout, "error": exec_result.error}
             print(json.dumps(out_dict, indent=2, default=str))
             return 0 if exec_result.success else 1
 

--- a/src/lackpy/infer/dispatch.py
+++ b/src/lackpy/infer/dispatch.py
@@ -133,7 +133,15 @@ class InferenceDispatcher:
             )
 
         provider_names = [p.name for p in self._providers if p.available()]
+        hint = ""
+        if set(provider_names) <= {"templates", "rules"}:
+            hint = (
+                " No LLM inference tier is configured — only the deterministic "
+                "templates/rules tiers ran, and they don't cover compositional "
+                "intents. Run `lackpyctl init --ollama-url <url>` to wire a local "
+                "model (see `.lackpy/config.toml.example`)."
+            )
         raise RuntimeError(
             f"All {len(provider_names)} providers failed to produce a valid program. "
-            f"Tried: {', '.join(provider_names)}. Last errors: {errors_by_provider}"
+            f"Tried: {', '.join(provider_names)}. Last errors: {errors_by_provider}.{hint}"
         )

--- a/src/lackpy/policy/sources/__init__.py
+++ b/src/lackpy/policy/sources/__init__.py
@@ -1,0 +1,7 @@
+"""Policy sources: per-source contributors of tool constraints.
+
+Each module here implements a :class:`~lackpy.policy.layer.PolicySource` that the
+:class:`~lackpy.policy.layer.PolicyLayer` resolves in order — the kit source
+(static grades/whitelist), the kibitzer source (runtime coaching), and the umwelt
+source (mode-aware environment constraints).
+"""

--- a/src/lackpy/run/base.py
+++ b/src/lackpy/run/base.py
@@ -15,6 +15,7 @@ class ExecutionResult:
     Attributes:
         success: Whether execution completed without error.
         output: The last expression's value, or None.
+        stdout: Text captured from ``print()`` calls during execution.
         error: Error message if execution failed.
         trace: Execution trace with tool call records.
         variables: Variables assigned during execution (excluding params and internals).
@@ -22,9 +23,22 @@ class ExecutionResult:
 
     success: bool
     output: Any = None
+    stdout: str = ""
     error: str | None = None
     trace: Trace = field(default_factory=Trace)
     variables: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def effective_output(self) -> Any:
+        """The value to hand back to a caller.
+
+        Prefers the typed last-expression value; falls back to the captured
+        stdout (stripped) when a program printed its answer instead of leaving
+        a bare final expression. Never coerces a present typed value.
+        """
+        if self.output is not None:
+            return self.output
+        return self.stdout.strip() or None
 
 
 class Executor(Protocol):

--- a/src/lackpy/run/runner.py
+++ b/src/lackpy/run/runner.py
@@ -45,6 +45,17 @@ class RestrictedRunner:
         trace = Trace()
         param_names = set(params.keys()) if params else set()
 
+        # Capture print() into a per-run buffer rather than letting it escape to
+        # the process stdout. Binding the buffer here (not redirecting the global
+        # sys.stdout) keeps capture thread-safe under the threaded execution path
+        # and lets the caller recover a value when a generated program ends in
+        # ``print(x)`` instead of a bare last expression.
+        captured: list[str] = []
+
+        def _capturing_print(*args: Any, sep: str = " ", end: str = "\n",
+                             file: Any = None, flush: bool = False) -> None:
+            captured.append(sep.join(str(a) for a in args) + end)
+
         traced_ns: dict[str, Any] = {}
         for name, fn in namespace.items():
             traced_ns[name] = make_traced(name, fn, trace, kibitzer_session=kibitzer_session)
@@ -52,6 +63,8 @@ class RestrictedRunner:
         for name in ALLOWED_BUILTINS:
             if name == "sort_by":
                 traced_ns[name] = _sort_by
+            elif name == "print":
+                traced_ns[name] = _capturing_print
             else:
                 traced_ns[name] = getattr(_builtins_mod, name)
 
@@ -84,7 +97,8 @@ class RestrictedRunner:
         try:
             _run_validated_code(code, exec_globals)
         except Exception as e:
-            return ExecutionResult(success=False, error=str(e), trace=trace)
+            return ExecutionResult(success=False, error=str(e), trace=trace,
+                                   stdout="".join(captured))
 
         output = exec_globals.get("__result__")
         variables = {
@@ -92,7 +106,8 @@ class RestrictedRunner:
             if k not in traced_ns and not k.startswith("_") and k not in param_names
         }
 
-        return ExecutionResult(success=True, output=output, trace=trace, variables=variables)
+        return ExecutionResult(success=True, output=output, trace=trace,
+                               variables=variables, stdout="".join(captured))
 
 
 def _run_validated_code(code: object, globals_dict: dict[str, Any]) -> None:

--- a/src/lackpy/service.py
+++ b/src/lackpy/service.py
@@ -627,7 +627,12 @@ class LackpyService:
                        for e in exec_result.trace.entries],
             "files_read": exec_result.trace.files_read,
             "files_modified": exec_result.trace.files_modified,
-            "output": exec_result.output,
+            # Prefer the typed last-expression value; if the program instead
+            # printed its answer (a common small-model habit), fall back to the
+            # captured stdout so the result isn't silently dropped. stdout is
+            # always surfaced so the caller can see it regardless.
+            "output": exec_result.effective_output,
+            "stdout": exec_result.stdout,
             "error": exec_result.error,
             "correction_strategy": gen_result.correction_strategy,
             "correction_attempts": gen_result.correction_attempts,

--- a/tests/run/test_runner.py
+++ b/tests/run/test_runner.py
@@ -2,7 +2,29 @@
 
 import pytest
 
+from lackpy.run.base import ExecutionResult
 from lackpy.run.runner import RestrictedRunner
+
+
+class TestEffectiveOutput:
+    def test_typed_output_wins_over_stdout(self):
+        # A present typed value is never overridden or coerced by captured stdout.
+        r = ExecutionResult(success=True, output=42, stdout="ignored\n")
+        assert r.effective_output == 42
+
+    def test_falls_back_to_stripped_stdout(self):
+        r = ExecutionResult(success=True, output=None, stdout="50\n")
+        assert r.effective_output == "50"
+
+    def test_none_when_no_output_and_no_stdout(self):
+        r = ExecutionResult(success=True, output=None, stdout="")
+        assert r.effective_output is None
+
+    def test_falsy_typed_output_is_preserved(self):
+        # output=0 / "" / [] are real values, not "missing" — keep them, don't
+        # fall through to stdout.
+        r = ExecutionResult(success=True, output=0, stdout="99\n")
+        assert r.effective_output == 0
 
 
 @pytest.fixture
@@ -45,6 +67,39 @@ class TestBasicExecution:
         result = runner.run("x = read_file('f.py')", mock_namespace)
         assert result.success
         assert result.output is None
+
+
+class TestPrintCapture:
+    def test_print_captured_to_stdout(self, runner, mock_namespace):
+        result = runner.run("print('hello')", mock_namespace)
+        assert result.success
+        assert result.stdout == "hello\n"
+
+    def test_print_does_not_escape_as_output(self, runner, mock_namespace):
+        # A trailing print(...) is a call returning None, so the typed output
+        # stays None — the value is recoverable from stdout instead.
+        result = runner.run("x = find_files('*.py')\nprint(len(x))", mock_namespace)
+        assert result.success
+        assert result.output is None
+        assert result.stdout == "2\n"
+
+    def test_print_multiple_args_and_calls(self, runner, mock_namespace):
+        result = runner.run("print('a', 'b')\nprint('c')", mock_namespace)
+        assert result.success
+        assert result.stdout == "a b\nc\n"
+
+    def test_no_print_means_empty_stdout(self, runner, mock_namespace):
+        result = runner.run("files = find_files('*.py')\nlen(files)", mock_namespace)
+        assert result.success
+        assert result.stdout == ""
+
+    def test_partial_stdout_on_runtime_error(self, runner):
+        def bad_read(path):
+            raise FileNotFoundError("no such file")
+        ns = {"read_file": bad_read}
+        result = runner.run("print('before')\nread_file('missing.py')", ns)
+        assert not result.success
+        assert result.stdout == "before\n"
 
 
 class TestParams:

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -57,6 +57,17 @@ class TestRunProgram:
         result = await service.run_program("import os", kit=["read_file"])
         assert not result.success
 
+    @pytest.mark.asyncio
+    async def test_run_program_print_recovered_via_effective_output(self, service):
+        # A program that prints its answer (instead of a bare last expression)
+        # must not silently drop the value: the typed output is None, but the
+        # printed text is captured and surfaced via effective_output.
+        result = await service.run_program("print(read_file('test.txt'))", kit=["read_file"])
+        assert result.success
+        assert result.output is None
+        assert result.stdout == "hello world\n"
+        assert result.effective_output == "hello world"
+
 
 class TestDelegate:
     @pytest.mark.asyncio
@@ -64,6 +75,13 @@ class TestDelegate:
         result = await service.delegate("read file test.txt", kit=["read_file"])
         assert result["success"]
         assert "read_file" in result["program"]
+
+    @pytest.mark.asyncio
+    async def test_delegate_result_carries_stdout(self, service):
+        # The delegate contract surfaces captured stdout so a printed answer is
+        # never lost, even when the typed output is populated.
+        result = await service.delegate("read file test.txt", kit=["read_file"])
+        assert "stdout" in result
 
     @pytest.mark.asyncio
     async def test_delegate_with_params(self, service):


### PR DESCRIPTION
## Out-of-the-box fixes for `delegate` + CLI docs alignment

Four atomic commits addressing the out-of-the-box experience of lackpy's `delegate`/run paths, plus a docs/CLI divergence.

### `fix(run)`: capture printed output so delegate/run never drop a value
Generated programs (especially from small coder models) often end in `print(x)` instead of a bare last expression. The runner captured only the last expression, so the value went to stdout and `output` came back `None` — the program computed the right answer but failed to hand it back.

- Capture `print()` into a per-run buffer via an injected closure (not a global `sys.stdout` redirect, which would race under the threaded executor path), exposed as `ExecutionResult.stdout`.
- Add `effective_output`: prefers the typed last-expression value, falls back to stripped stdout, and **never coerces** a present value (`0` / `""` / `[]` preserved).
- Apply consistently across **all three** consumers — `delegate`, file runs, stdin runs — and surface `stdout` in each result.
- Tests cover the mechanism, the payoff (`run_program` on a print-ending program returns the value), the delegate contract, and the non-coercion guarantee.

### `fix(infer)`: actionable error when no LLM tier is configured
Out of the box (no `.lackpy/config.toml`) only the deterministic templates/rules tiers run, so a compositional intent failed with an opaque `All 2 providers failed`. Now, when available providers are a subset of `{templates, rules}`, the error points at `lackpyctl init`. The model choice stays a per-machine config decision — nothing baked into the package default.

### `fix(packaging)`: add `policy/sources/__init__.py` so api docs collect
`src/lackpy/policy/sources/` was the only regular subpackage missing an `__init__.py`. Runtime imports survived on the PEP 420 fallback, but griffe couldn't recurse it — so `mkdocs build --strict` failed to autodoc the `policy.sources.*` classes, **breaking the ReadTheDocs build**. Fixed; `--strict` now passes.

### `docs`: align CLI docs to the real `lackpy -c` / `lackpyctl` interface
The docs documented a `lackpy <subcommand>` interface that doesn't exist. The real CLI is flag-based (`lackpy -c "<intent>"` with `--generate`/`--validate`/`--create`; file runs by positional path) and all management lives under `lackpyctl`. A user copying the README failed on line 1.

- Rewrote `reference/cli.md` to the two real entry points; documents the new `stdout` field.
- Fixed every invocation across README + narrative + concepts docs; made the headline model-agnostic.
- Corrected a conceptual bug: the "ratchet" docs conflated `--create` (saves a run-by-path Lackey file) with the tier-0 templates cache (only `.tmpl` files with a `pattern:` are intent-matched, via `svc.create(pattern=...)`).

### Verification
- `694 passed, 1 skipped` (live-Ollama tests excluded — environmental `ReadTimeout`).
- `mkdocs build --strict` passes.

Independent of #16 (blq-init) — can land in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
