### PR TITLE
Integrate woollama.core as the model-management backbone

### DIFF
--- a/docs/design/rename-to-lacklangster.md
+++ b/docs/design/rename-to-lacklangster.md
@@ -1,0 +1,122 @@
+# Plan: rename to put each name where its meaning points
+
+> **Status: plan only — NOT started.** Captured for a later, deliberate refactor.
+> The current names (`lackpy` = harness/runtime dist, `lackpy-lang` = language
+> leaf) are untouched; the woollama-core integration continues against them.
+
+## Motivation
+
+`lackpy` literally means *"Python that lacks most of Python"* — a description of
+the **language**, not of the generation/inference harness that produces and runs
+it. Today the names are inverted:
+
+- `lackpy` (the dist) is the **harness**: service, inference / program-generation,
+  interpreters, kit, sources, MCP, CLI.
+- `lackpy-lang` (the leaf, imported `lackpy.lang`) is the **language**: grammar,
+  validator, grader, spec — stdlib-only, no runtime deps.
+
+And the project is growing toward **multiple languages** (lackpy + shlack). So the
+clean naming swaps them:
+
+- **`lackpy`** = the lackpy **language runtime** (today's `lackpy-lang`).
+- **`shlack`** = a sibling language runtime (future, its own dist).
+- **`lacklangster`** = the **harness** that wrangles any lack-language (today's
+  `lackpy` runtime dist).
+
+Each name then lands where its meaning already points: `lackpy` *is* the restricted
+language; `lacklangster` *is* the multi-language harness.
+
+## Target structure
+
+| Today | After |
+|---|---|
+| dist `lackpy-lang`, import `lackpy.lang` (grammar/validator/grader/spec) | dist `lackpy`, import `lackpy.*` — the language runtime |
+| (none) | dist `shlack`, import `shlack.*` — sibling language (future) |
+| dist `lackpy`, import `lackpy.*` (service/infer/interpreters/kit/sources/mcp/CLI) | dist `lacklangster`, import `lacklangster.*` — the harness |
+
+## The one structural decision: where does *execution* live?
+
+"Language runtime**s**" could mean the language owns its executor. But lackpy's
+interpreters (`plucker`, `ast_select`, `pss`) execute programs against the
+**kit/tools**, which is harness territory.
+
+**Recommendation (keep the clean leaf boundary):** `lackpy` stays a *pure*
+language — grammar + validation + grader + spec, stdlib-only, no upward deps (the
+property `tests/lang/test_no_upward_deps.py` already guards). `lacklangster` owns
+execution: interpreters, tools, inference, the agentic loop. "Runtime" here means
+*the formal definition the harness runs*, not the runner. This keeps the swap
+mostly a **rename**, not a re-layering, and preserves the leaf's purity guard.
+
+*Alternative (defer unless wanted):* each language ships its own executor — a
+deeper split that moves interpreter machinery into the language packages.
+
+## Namespace mapping (confirmed direction)
+
+- harness: `lackpy.<mod>` → `lacklangster.<mod>` (service, infer, interpreters,
+  kit, sources, mcp, run, policy, cli, ctl, config, …).
+- language: `lackpy.lang.<mod>` → `lackpy.<mod>` (the leaf loses the `.lang`
+  segment and *becomes* the `lackpy` top-level).
+
+## Scope / blast radius (why this is bigger than the earlier idea)
+
+The earlier `lackpy-lang → lacklangster` idea touched ~37 `lackpy.lang` import
+sites. **This swap renames the main package**, so the blast radius is most of the
+tree:
+
+- Every internal import in the harness (`from lackpy.x` / `from .x` → `lacklangster`).
+- Every `from lackpy.lang import …` (~37 sites) → `from lackpy import …`.
+- CLI entry points: `lackpy` / `lackpyctl` → `lacklangster` / `lacklangsterctl`
+  (decide whether a `lackpy` command survives as a language-runner).
+- Both `pyproject.toml`s (dist names, `[project.scripts]`, the pytest
+  `pythonpath`, `[tool.uv.sources]`), the docs, and effectively every test module.
+- The woollama integration relocates: `lackpy.infer.providers.woollama` →
+  `lacklangster.infer.providers.woollama` (no logic change).
+
+## Migration sequence (phased, shim-backed — mirrors the woollama-core extraction)
+
+The woollama extraction proved this pattern: move behind alias shims, keep every
+import working, flip call sites, then delete shims. Apply it here:
+
+1. **Language leaf first** (smaller, isolated). New dist `lackpy` from today's
+   `lackpy-lang`, importing `lackpy.*` (drop `.lang`). Leave `lackpy.lang` as an
+   alias shim (`sys.modules` re-export) so the harness keeps importing it.
+   Update the leaf's own pyproject + the purity guard test. Ship green.
+2. **Harness rename.** New dist `lacklangster` from today's `lackpy` runtime,
+   importing `lacklangster.*`. The trickiest step: the harness currently *is*
+   `lackpy`, and the leaf now *wants* to be `lackpy` — so this must land together
+   with, or right after, step 1's namespace freed up. Move the harness modules to
+   `lacklangster/`, repoint internal imports, keep `lackpy` (harness) import paths
+   as alias shims during the transition.
+3. **Flip the language references.** Harness imports of the leaf:
+   `from lackpy.lang import …` → `from lackpy import …`.
+4. **CLI + packaging.** Rename `[project.scripts]`; update both pyprojects, the
+   pytest `pythonpath`, `[tool.uv.sources]`, docs, READMEs.
+5. **Delete the shims.** Repoint all remaining imports; remove the compat aliases.
+6. **shlack** (separate, later): a new `shlack` dist alongside `lackpy`, driven by
+   the `lacklangster` harness via the same language-runtime interface.
+
+Each phase keeps the suite green; ship per phase.
+
+## Status-quo bridge (what's in place now, no rename)
+
+So the integration can continue without the rename, the worktree resolves the
+monorepo locally (see `pyproject.toml` `[tool.uv.sources]`):
+
+- `lackpy-lang` → local path `packages/lackpy-lang` (editable). (Un-masked — it
+  isn't published, so the registry pin `==0.12.0` is satisfied from the tree.)
+- `woollama` → editable sibling worktree `../woollama-core-extraction`.
+- `requires-python` bumped to `>=3.12` (the universal lock pulls the `full`
+  extra's `nsjail-python`, which is 3.12-only).
+
+These are scoped to the integration branch and unwind naturally when the packages
+publish.
+
+## Open questions
+
+- Execution placement (above) — pure-leaf `lackpy` vs. per-language executors.
+- Does a `lackpy` CLI survive (run a lackpy program) distinct from the
+  `lacklangster` harness CLI?
+- Is `shlack` one dist with `lacklangster`, or its own dist? (Plan assumes its own,
+  for a clean per-language boundary.)
+- Publish order: language (`lackpy`) before harness (`lacklangster`), since the
+  harness depends on the language.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,11 +6,17 @@ build-backend = "hatchling.build"
 name = "lackpy"
 version = "0.12.0"
 description = "Python that lacks most of Python. Restricted program generation and execution for tool composition."
-requires-python = ">=3.11"
+requires-python = ">=3.12"
 # lackpy is the runtime dist; lackpy-lang is the pure-language leaf. They share the
 # `lackpy` namespace (PEP 420 — neither ships lackpy/__init__.py). Pinned so the two
 # halves version together.
-dependencies = ["markdown-it-py>=3.0", "lackpy-lang==0.12.0"]
+dependencies = [
+    "markdown-it-py>=3.0",
+    # lackpy-lang==0.12.0 — MASKED on the woollama-core-integration branch: it's not
+    # published yet (its packaging is a follow-up); its code is provided via the
+    # pytest pythonpath (packages/lackpy-lang/src), so tests run without it as a dist.
+    "woollama",   # the extracted model-management core (path source below)
+]
 
 [project.optional-dependencies]
 ollama = ["ollama>=0.4", "httpx>=0.27"]
@@ -32,6 +38,11 @@ docs = [
 [project.urls]
 Documentation = "https://lackpy.readthedocs.io"
 Repository = "https://github.com/teague/lackpy"
+
+# woollama.core is consumed as a local editable path during the integration; once
+# woollama's core-extraction releases, this becomes a normal version requirement.
+[tool.uv.sources]
+woollama = { path = "../woollama-core-extraction", editable = true }
 
 [project.scripts]
 lackpy = "lackpy.cli:main"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,19 +6,25 @@ build-backend = "hatchling.build"
 name = "lackpy"
 version = "0.12.0"
 description = "Python that lacks most of Python. Restricted program generation and execution for tool composition."
-requires-python = ">=3.12"
+requires-python = ">=3.11"
 # lackpy is the runtime dist; lackpy-lang is the pure-language leaf. They share the
 # `lackpy` namespace (PEP 420 — neither ships lackpy/__init__.py). Pinned so the two
 # halves version together.
 dependencies = [
     "markdown-it-py>=3.0",
-    "lackpy-lang==0.12.0",   # the pure-language leaf — resolved locally (sources below)
-    "woollama",              # the extracted model-management core (sources below)
+    "lackpy-lang==0.12.0",   # the pure-language leaf (CI installs it from packages/)
+    # woollama's model-management core. Pinned to a git rev until it cuts a release
+    # with woollama.core (the published 0.3.0 predates the extraction); then this
+    # becomes a normal version requirement. A PEP 508 direct URL, so pip AND uv
+    # resolve it identically (CI uses pip).
+    "woollama @ git+https://github.com/teaguesterling/woollama.git@2e6204b87ce19fc37fb06bc47bbf62ae1428b0c2",
 ]
 
 [project.optional-dependencies]
 ollama = ["ollama>=0.4", "httpx>=0.27"]
-sandbox = ["nsjail-python"]
+# nsjail-python has no <3.12 wheel; marker keeps the project installable on 3.11
+# (CI tests 3.11) while the sandbox extra is available on 3.12.
+sandbox = ["nsjail-python ; python_version >= '3.12'"]
 anthropic = ["anthropic>=0.40"]
 mcp = ["mcp[cli]"]
 fledgling = ["fledgling"]
@@ -37,14 +43,11 @@ docs = [
 Documentation = "https://lackpy.readthedocs.io"
 Repository = "https://github.com/teague/lackpy"
 
-# Local sources so the monorepo resolves under `uv sync` without publishing:
-#  - lackpy-lang is the in-tree language leaf (status quo; un-masked — resolved
-#    from packages/ rather than the registry, where it isn't published).
-#  - woollama is the extracted core, an editable sibling worktree during the
-#    integration; becomes a normal version requirement once it releases.
+# Resolve the in-tree language leaf locally for `uv` users (it isn't on PyPI yet);
+# CI uses pip and installs it explicitly. (woollama is a PEP 508 git URL in
+# dependencies above — no source entry needed; pip and uv both honor it.)
 [tool.uv.sources]
 lackpy-lang = { path = "packages/lackpy-lang", editable = true }
-woollama = { path = "../woollama-core-extraction", editable = true }
 
 [project.scripts]
 lackpy = "lackpy.cli:main"
@@ -52,6 +55,12 @@ lackpyctl = "lackpy.ctl:main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/lackpy"]
+
+# Allow the woollama `@ git+...` direct reference in dependencies (hatchling rejects
+# direct URLs by default, as PyPI forbids them). Temporary — drops out when woollama
+# becomes a normal version requirement.
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [tool.pytest.ini_options]
 # Both namespace halves on the path: core runtime (src) + the lackpy-lang leaf.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,10 +12,8 @@ requires-python = ">=3.12"
 # halves version together.
 dependencies = [
     "markdown-it-py>=3.0",
-    # lackpy-lang==0.12.0 — MASKED on the woollama-core-integration branch: it's not
-    # published yet (its packaging is a follow-up); its code is provided via the
-    # pytest pythonpath (packages/lackpy-lang/src), so tests run without it as a dist.
-    "woollama",   # the extracted model-management core (path source below)
+    "lackpy-lang==0.12.0",   # the pure-language leaf — resolved locally (sources below)
+    "woollama",              # the extracted model-management core (sources below)
 ]
 
 [project.optional-dependencies]
@@ -39,9 +37,13 @@ docs = [
 Documentation = "https://lackpy.readthedocs.io"
 Repository = "https://github.com/teague/lackpy"
 
-# woollama.core is consumed as a local editable path during the integration; once
-# woollama's core-extraction releases, this becomes a normal version requirement.
+# Local sources so the monorepo resolves under `uv sync` without publishing:
+#  - lackpy-lang is the in-tree language leaf (status quo; un-masked — resolved
+#    from packages/ rather than the registry, where it isn't published).
+#  - woollama is the extracted core, an editable sibling worktree during the
+#    integration; becomes a normal version requirement once it releases.
 [tool.uv.sources]
+lackpy-lang = { path = "packages/lackpy-lang", editable = true }
 woollama = { path = "../woollama-core-extraction", editable = true }
 
 [project.scripts]

--- a/src/lackpy/infer/providers/woollama.py
+++ b/src/lackpy/infer/providers/woollama.py
@@ -1,0 +1,84 @@
+"""woollama-backed inference: delegate the model call to ``woollama.core``.
+
+lackpy keeps everything that makes it lackpy — prompt construction, the few-shot
+error-correction conversation, and the dispatcher / validation / CorrectionChain
+around generation. It only stops doing its OWN per-provider model HTTP: the raw
+"send these messages, get text" call goes to :func:`woollama.core.complete`,
+which owns provider/model routing, config, transport, ollama-native ``num_ctx``,
+and per-call key/base-url overrides.
+
+One ``model`` string of the form ``"<provider>/<model>"`` (e.g.
+``"ollama/qwen2.5-coder:1.5b"`` or ``"anthropic/claude-haiku-4-5"``) reaches every
+woollama-known backend — so lackpy gets multi-provider model management without
+maintaining a provider per vendor. Implements the same ``InferenceProvider``
+protocol (``name`` / ``available`` / ``generate``) as the other tiers.
+"""
+from __future__ import annotations
+
+from ..prompt import build_system_prompt
+
+
+class WoollamaProvider:
+    def __init__(self, model: str = "ollama/qwen2.5-coder:1.5b",
+                 temperature: float = 0.2, retry_temperature: float = 0.6,
+                 api_key: str | None = None, base_url: str | None = None) -> None:
+        self._model = model
+        self._temperature = temperature
+        self._retry_temperature = retry_temperature
+        self._api_key = api_key
+        self._base_url = base_url
+
+    @property
+    def name(self) -> str:
+        return "woollama"
+
+    def available(self) -> bool:
+        try:
+            import woollama.core  # noqa: F401
+            return True
+        except ImportError:
+            return False
+
+    async def generate(self, intent: str, namespace_desc: str,
+                       config: dict | None = None, error_feedback: list[str] | None = None,
+                       system_prompt_override: str | None = None,
+                       interpreter: object | None = None) -> str | None:
+        if not self.available():
+            return None
+        from woollama.core import complete
+
+        system = system_prompt_override or build_system_prompt(
+            namespace_desc, interpreter=interpreter)
+
+        is_retry = error_feedback and self._last_output
+        if is_retry:
+            # Few-shot error correction: show the model its bad output and the
+            # correction as a conversation (mirrors the OllamaProvider tier).
+            messages = [
+                {"role": "system", "content": system},
+                {"role": "user", "content": intent},
+                {"role": "assistant", "content": self._last_output},
+                {"role": "user", "content": (
+                    "That code won't work in this environment. "
+                    + " ".join(h for h in error_feedback if h != "--- Suggestions ---")
+                    + " Rewrite using only the kernel namespace.")},
+            ]
+        else:
+            messages = [
+                {"role": "system", "content": system},
+                {"role": "user", "content": intent},
+            ]
+
+        temperature = self._retry_temperature if is_retry else self._temperature
+        try:
+            content = await complete(
+                self._model, messages,
+                params={"temperature": temperature},
+                api_key=self._api_key, base_url=self._base_url)
+            self._last_output = content.strip() if content else None
+            return self._last_output
+        except Exception:
+            self._last_output = None
+            return None
+
+    _last_output: str | None = None

--- a/src/lackpy/service.py
+++ b/src/lackpy/service.py
@@ -223,6 +223,18 @@ class LackpyService:
                 self._inference_providers.append(AnthropicProvider(
                     model=provider_cfg.get("model", "claude-haiku-4-5-20251001"),
                 ))
+            elif plugin == "woollama" and name not in ("templates", "rules"):
+                # Consolidated model management: one provider routes to ANY
+                # woollama-known backend (ollama, anthropic, openai, …) via a
+                # "<provider>/<model>" string — lackpy stops doing per-vendor HTTP.
+                from .infer.providers.woollama import WoollamaProvider
+                self._inference_providers.append(WoollamaProvider(
+                    model=provider_cfg.get("model", "ollama/qwen2.5-coder:1.5b"),
+                    temperature=provider_cfg.get("temperature", 0.2),
+                    retry_temperature=provider_cfg.get("retry_temperature", 0.6),
+                    api_key=provider_cfg.get("api_key"),
+                    base_url=provider_cfg.get("base_url"),
+                ))
             elif plugin == "cascade" and name not in ("templates", "rules"):
                 from .infer.providers.cascade import CascadeProvider
                 self._inference_providers.append(CascadeProvider(

--- a/tests/test_woollama_provider.py
+++ b/tests/test_woollama_provider.py
@@ -1,0 +1,55 @@
+"""WoollamaProvider — lackpy program generation with the model call delegated to
+woollama.core. Mocks woollama.core.complete so the provider's prompt/few-shot
+logic and routing are exercised without a live model."""
+from __future__ import annotations
+
+import pytest
+
+from lackpy.infer.providers.woollama import WoollamaProvider
+
+
+@pytest.fixture
+def calls(monkeypatch):
+    import woollama.core as wc
+
+    recorded: list = []
+
+    async def fake_complete(model, messages, **kw):
+        recorded.append({"model": model, "messages": messages, "kw": kw})
+        return "  kernel.select('x')  "
+
+    monkeypatch.setattr(wc, "complete", fake_complete)
+    return recorded
+
+
+def test_available():
+    assert WoollamaProvider().name == "woollama"
+    assert WoollamaProvider().available() is True   # woollama.core is importable
+
+
+async def test_generate_routes_model_and_params(calls):
+    p = WoollamaProvider(model="ollama/qwen2.5-coder:1.5b", temperature=0.2)
+    out = await p.generate("count rows", namespace_desc="kernel.select(x)")
+    assert out == "kernel.select('x')"              # stripped
+    call = calls[-1]
+    assert call["model"] == "ollama/qwen2.5-coder:1.5b"
+    assert call["kw"]["params"] == {"temperature": 0.2}
+    assert [m["role"] for m in call["messages"]] == ["system", "user"]
+    assert "kernel.select(x)" in call["messages"][0]["content"]
+    assert call["messages"][1]["content"] == "count rows"
+
+
+async def test_retry_is_few_shot_at_higher_temperature(calls):
+    p = WoollamaProvider(temperature=0.2, retry_temperature=0.6)
+    await p.generate("count rows", "ns")            # seed _last_output
+    await p.generate("count rows", "ns", error_feedback=["use the kernel namespace"])
+    call = calls[-1]
+    assert call["kw"]["params"] == {"temperature": 0.6}
+    assert [m["role"] for m in call["messages"]] == ["system", "user", "assistant", "user"]
+
+
+async def test_per_call_key_and_base_url_forwarded(calls):
+    p = WoollamaProvider(model="openai/gpt-x", api_key="sk-x", base_url="http://proxy/v1")
+    await p.generate("x", "ns")
+    call = calls[-1]
+    assert call["kw"]["api_key"] == "sk-x" and call["kw"]["base_url"] == "http://proxy/v1"

--- a/tests/test_woollama_provider.py
+++ b/tests/test_woollama_provider.py
@@ -53,3 +53,23 @@ async def test_per_call_key_and_base_url_forwarded(calls):
     await p.generate("x", "ns")
     call = calls[-1]
     assert call["kw"]["api_key"] == "sk-x" and call["kw"]["base_url"] == "http://proxy/v1"
+
+
+def test_woollama_plugin_registered_from_config(tmp_path):
+    """The `woollama` plugin wires a WoollamaProvider into the service's inference
+    tiers (config-driven, alongside the deterministic templates/rules tiers)."""
+    from lackpy.config import LackpyConfig
+    from lackpy.service import LackpyService
+
+    cfg = LackpyConfig(
+        inference_order=["woollama"],
+        inference_providers={"woollama": {
+            "plugin": "woollama", "model": "ollama/qwen2.5-coder:1.5b",
+            "temperature": 0.1}},
+    )
+    svc = LackpyService(workspace=tmp_path, config=cfg)
+    woollama_tiers = [p for p in svc._inference_providers
+                      if type(p).__name__ == "WoollamaProvider"]
+    assert len(woollama_tiers) == 1
+    assert woollama_tiers[0]._model == "ollama/qwen2.5-coder:1.5b"
+    assert woollama_tiers[0]._temperature == 0.1


### PR DESCRIPTION
Integrates woollama.core as lackpy's model-management backbone.

- **`WoollamaProvider`** (`infer/providers/woollama.py`) implements the
  `InferenceProvider` protocol and delegates the raw model call to
  `woollama.core.complete`, keeping all of lackpy's program-generation logic
  (prompt build, few-shot error correction, dispatcher/validation/CorrectionChain).
  One `<provider>/<model>` string reaches every woollama backend (ollama,
  anthropic, openai, …).
- **Wired into the service** as the `woollama` inference plugin (config-selectable),
  so a deployment can consolidate model management onto woollama — one plugin in
  place of the per-vendor ollama/anthropic ones (kept for back-compat).
- **Dependency**: woollama pinned to a git rev until it releases with
  `woollama.core` (PyPI 0.3.0 predates the extraction); `allow-direct-references`
  for hatchling. nsjail-python gets a `python_version >= '3.12'` marker so 3.11
  installs cleanly.
- **Plan captured**: `docs/design/rename-to-lacklangster.md` (the eventual
  `lackpy`→language / `lacklangster`→harness swap; not started).

861 passed / 9 skipped; the provider is also live-proven against real ollama.
