### PR TITLE
feat(observ): record delegations as blq invocations (bird format)

### DIFF
--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -75,6 +75,7 @@ Validation is also performed inside `InferenceDispatcher` after each provider at
 | `lackpy.infer.providers.*` | `TemplatesProvider`, `RulesProvider`, `WoollamaProvider`, `CascadeProvider` | `infer.prompt` |
 | `lackpy.cli` | `argparse`-based CLI; calls `LackpyService` | `service` |
 | `lackpy.mcp` | MCP server exposing the service as tools | `service` |
+| `lackpy.observ` | `record_delegation()` — best-effort write of a delegation into blq's invocation DB | `blq` (optional) |
 
 ---
 
@@ -85,6 +86,14 @@ Validation is also performed inside `InferenceDispatcher` after each provider at
 - The MCP server and CLI always have identical behaviour.
 - Third-party code using the Python API benefits from the same validation, tracing, and grade computation as the built-in interfaces.
 - Configuration is loaded once at `LackpyService.__init__` and propagated automatically.
+
+---
+
+## Delegation traces (blq)
+
+When the workspace has a `.bird/` (i.e. [blq](https://github.com/teaguesterling/blq) is in use) and `blq-cli` is installed, each `delegate()` is recorded as a blq **invocation** under the `delegate` source — queryable alongside build/test runs (`blq history`, `blq query`, `blq output`). The generated program is stored as the run's output; the structured summary (grade, generation tier, timings, tool names) rides in the invocation's `environment.lackpy` JSON; a failed delegation adds one `error` event.
+
+Recording is **best-effort** (`lackpy.observ.record_delegation`): a missing blq, no `.bird/`, or a concurrent writer holding the single-writer DuckDB lock is a silent no-op — it never affects the delegation result. (Replaces the older `.lackpy/traces.jsonl` sink.)
 
 ---
 

--- a/src/lackpy/observ.py
+++ b/src/lackpy/observ.py
@@ -1,0 +1,104 @@
+"""Best-effort recording of ``delegate()`` results into blq's invocation database.
+
+When a workspace has a ``.bird/`` (i.e. blq is in use there) and ``blq-cli`` is
+installed, each delegation is written as a blq invocation under the ``delegate``
+source — so delegations become queryable alongside build/test runs (``blq history``,
+``blq query``, ``blq output``). This replaces the old ``.lackpy/traces.jsonl`` sink
+with blq's "bird invocation format".
+
+Entirely best-effort: a missing blq, no ``.bird/``, or a concurrent writer holding
+the single-writer DuckDB lock all result in a silent no-op. Recording must never
+affect the delegation result.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+
+def record_delegation(workspace: Path, intent: str, result: dict[str, Any]) -> str | None:
+    """Record a ``delegate()`` result as a blq invocation.
+
+    Returns the blq run id, or ``None`` when nothing was recorded — blq not
+    installed, the workspace has no ``.bird/``, or any error (e.g. a concurrent
+    blq writer holds the DuckDB lock). Never raises.
+    """
+    try:
+        from blq.storage import BlqStorage
+    except ImportError:
+        return None
+
+    bird_dir = Path(workspace) / ".bird"
+    if not bird_dir.is_dir():
+        return None
+
+    try:
+        run_meta, events, output = _to_invocation(bird_dir, intent, result)
+        storage = BlqStorage.open(bird_dir)
+        try:
+            return storage.write_run(run_meta, events=events, output=output)
+        finally:
+            try:
+                storage.close()
+            except Exception:
+                pass
+    except Exception:
+        # A concurrent blq writer (single-writer DuckDB), a schema mismatch, etc.
+        # must never break delegation. Swallow and move on.
+        return None
+
+
+def _to_invocation(
+    bird_dir: Path, intent: str, result: dict[str, Any]
+) -> tuple[dict[str, Any], list[dict[str, Any]] | None, bytes | None]:
+    """Map a delegate() result dict onto blq's (run_meta, events, output) shape."""
+    total_ms = result.get("total_time_ms") or 0
+    completed = datetime.now()
+    started = completed - timedelta(milliseconds=total_ms)
+    success = bool(result.get("success"))
+
+    run_meta = {
+        "command": f'lackpy delegate "{intent[:200]}"',
+        "source_name": "delegate",
+        "source_type": "import",
+        "tag": "delegate",
+        "exit_code": 0 if success else 1,
+        "started_at": started.isoformat(),
+        "completed_at": completed.isoformat(),
+        "cwd": str(bird_dir.parent),
+        # write_run forwards `environment` (JSON) but NOT `extension_data`, so the
+        # structured delegation summary rides in `environment.lackpy`.
+        "environment": {
+            "lackpy": {
+                "success": success,
+                "grade": result.get("grade"),
+                "generation_tier": result.get("generation_tier"),
+                "generation_time_ms": result.get("generation_time_ms"),
+                "execution_time_ms": result.get("execution_time_ms"),
+                "total_time_ms": total_ms,
+                "tools": [e.get("tool") for e in result.get("trace") or []],
+                "files_read": result.get("files_read"),
+                "files_modified": result.get("files_modified"),
+                "correction_attempts": result.get("correction_attempts"),
+            }
+        },
+    }
+
+    # Only failures are diagnostics — one error event so `events(severity="error")`
+    # surfaces failed delegations. Successful runs add no events.
+    events = None
+    if not success:
+        events = [{
+            "severity": "error",
+            "event_type": "delegation_failure",
+            "message": result.get("error") or "delegation failed",
+            "tool_name": "lackpy",
+            "category": "delegate",
+        }]
+
+    # The generated program is the artifact worth eyeballing via `blq output`.
+    program = result.get("program") or ""
+    output = program.encode("utf-8") if program else None
+
+    return run_meta, events, output

--- a/src/lackpy/service.py
+++ b/src/lackpy/service.py
@@ -649,6 +649,12 @@ class LackpyService:
         }
         if kibitzer_suggestions:
             result["kibitzer_suggestions"] = kibitzer_suggestions
+
+        # Best-effort: record this delegation as a blq invocation when the
+        # workspace uses blq (.bird/ present). No-op otherwise; never raises.
+        from .observ import record_delegation
+        record_delegation(self._workspace, intent, result)
+
         return result
 
     def parse_lackey(self, path: Path) -> Any:

--- a/tests/test_observ.py
+++ b/tests/test_observ.py
@@ -1,0 +1,101 @@
+"""record_delegation — best-effort write of a delegate() result into blq.
+
+blq.storage.BlqStorage.open is monkeypatched with a fake so these run without a
+real .bird/ DuckDB; the no-bird and error paths assert the best-effort guarantees.
+"""
+from __future__ import annotations
+
+import pytest
+
+from lackpy.observ import record_delegation
+
+
+def _result(success: bool = True) -> dict:
+    return {
+        "success": success,
+        "program": "x = read_file('a')\nx",
+        "grade": {"w": 1, "d": 1},
+        "generation_tier": "woollama",
+        "generation_time_ms": 12.0,
+        "execution_time_ms": 3.0,
+        "total_time_ms": 15.0,
+        "trace": [{"step": 1, "tool": "read_file", "args": {}, "result": "...",
+                   "duration_ms": 1, "success": True, "error": None}],
+        "files_read": ["a"],
+        "files_modified": [],
+        "output": "...",
+        "stdout": "",
+        "error": None if success else "boom",
+        "correction_strategy": None,
+        "correction_attempts": 0,
+    }
+
+
+class _FakeStorage:
+    def __init__(self):
+        self.calls: list = []
+
+    def write_run(self, run_meta, events=None, output=None):
+        self.calls.append((run_meta, events, output))
+        return f"run-{len(self.calls)}"
+
+    def close(self):
+        pass
+
+
+@pytest.fixture
+def fake_blq(tmp_path, monkeypatch):
+    blq_storage = pytest.importorskip("blq.storage")  # optional dep; skip if absent
+    (tmp_path / ".bird").mkdir()
+    fake = _FakeStorage()
+    monkeypatch.setattr(blq_storage.BlqStorage, "open", staticmethod(lambda d: fake))
+    return fake
+
+
+def test_noop_without_bird(tmp_path):
+    # No .bird/ in the workspace → nothing recorded, no error.
+    assert record_delegation(tmp_path, "do x", _result()) is None
+
+
+def test_writes_run_for_success(tmp_path, fake_blq):
+    rid = record_delegation(tmp_path, "count rows", _result())
+    assert rid == "run-1"
+    (run_meta, events, output), = fake_blq.calls
+    assert run_meta["source_name"] == "delegate"
+    assert run_meta["source_type"] == "import"
+    assert run_meta["tag"] == "delegate"
+    assert run_meta["exit_code"] == 0
+    assert run_meta["command"] == 'lackpy delegate "count rows"'
+    lackpy_meta = run_meta["environment"]["lackpy"]
+    assert lackpy_meta["generation_tier"] == "woollama"
+    assert lackpy_meta["tools"] == ["read_file"]
+    assert events is None                       # no events on success
+    assert output == b"x = read_file('a')\nx"   # the generated program
+
+
+def test_failure_records_error_event(tmp_path, fake_blq):
+    record_delegation(tmp_path, "x", _result(success=False))
+    run_meta, events, _ = fake_blq.calls[0]
+    assert run_meta["exit_code"] == 1
+    assert len(events) == 1
+    assert events[0]["severity"] == "error"
+    assert events[0]["message"] == "boom"
+    assert events[0]["tool_name"] == "lackpy"
+
+
+def test_intent_is_truncated(tmp_path, fake_blq):
+    record_delegation(tmp_path, "z" * 500, _result())
+    cmd = fake_blq.calls[0][0]["command"]
+    assert cmd == 'lackpy delegate "' + "z" * 200 + '"'
+
+
+def test_swallows_storage_errors(tmp_path, monkeypatch):
+    # A concurrent writer / lock error must never propagate out of delegate.
+    blq_storage = pytest.importorskip("blq.storage")  # optional dep; skip if absent
+    (tmp_path / ".bird").mkdir()
+
+    def boom(_):
+        raise RuntimeError("database is locked")
+
+    monkeypatch.setattr(blq_storage.BlqStorage, "open", staticmethod(boom))
+    assert record_delegation(tmp_path, "x", _result()) is None


### PR DESCRIPTION
## Record delegations as blq invocations (bird format)

Reimplements the closed #2 delegation-trace logging in **blq's "bird invocation format"** instead of the old `.lackpy/traces.jsonl`. When a workspace has a `.bird/` (i.e. blq is in use) and `blq-cli` is installed, each `delegate()` is recorded as a blq **invocation** under the `delegate` source — queryable alongside build/test runs (`blq history` / `query` / `output`).

### What it does
- **`lackpy.observ.record_delegation()`** maps a `delegate()` result onto blq's public `write_run(run_meta, events, output)`:
  - command = the intent (truncated), `source_name`/`tag` = `delegate`, `source_type` = `import`
  - the generated program → the run's `output` (eyeball via `blq output`)
  - structured summary (grade, generation tier, timings, tool names, files touched) → `environment.lackpy`
  - one `severity="error"` event **only** on failure, so `events(severity="error")` surfaces failed delegations
- Wired into `LackpyService.delegate()` just before return.

### Safety
- **Gated** on `.bird/` existence + blq importability — a no-op in workspaces that don't use blq, and never creates a `.bird/`.
- **Best-effort**: a missing blq, no `.bird/`, or a concurrent writer holding the single-writer DuckDB lock is swallowed — recording never affects the delegation result. `BlqStorage.open` fails fast on lock contention, so the synchronous hook can't stall the event loop.

### Design notes (verified against blq source)
- BIRD's "Buffer" is the in-DB attempts/outcomes pattern, **not** an external JSONL append spool — so `write_run` (direct DB, best-effort) is the correct write path.
- `write_run` forwards `environment`/`ci`/`git_*` but **silently drops `extension_data`** — so the structured summary rides in `environment.lackpy` (noted in a code comment for when blq forwards it).

### Tests
- Unit: mapping, failure event, intent truncation, no-`.bird/` no-op, error-swallowing.
- **Real integration check** against an actual `.bird/` DuckDB (write + query-back showed the row under `source_name='delegate'`).
- Full suite: **705 passed, 1 skipped**; `mkdocs build --strict` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
