### PR TITLE
feat(woollama): config-driven options/params + real contract test; cap the dep

### DIFF
--- a/.lackpy/config.toml.example
+++ b/.lackpy/config.toml.example
@@ -23,6 +23,12 @@ model = "ollama/qwen2.5-coder:1.5b"
 # woollama's defaults (Ollama at http://localhost:11434, cloud providers built in).
 base_url = "http://localhost:11434/v1"
 temperature = 0.2
+# Extra knobs, all optional:
+#   options = ollama-native fields. Setting num_ctx routes ollama/* through the
+#             native /api/chat endpoint (which honors it) instead of /v1.
+#   params  = OpenAI top-level request fields (max_tokens, top_p, …).
+# options = { num_ctx = 8192 }
+# params = { max_tokens = 512, top_p = 0.9 }
 
 # Optional: a raw-completion cascade strategy for small coder models. This is NOT a
 # vendor backend — it uses Ollama's /api/generate (raw, pattern-completion) which

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,10 @@ dependencies = [
     # woollama's model-management core (provides the `woollama.core` namespace):
     # provider/model routing, transport, recipe orchestration. Self-contained wheel,
     # no extra deps. lackpy uses only `woollama.core`, not the full woollama router.
-    "woollama-core>=0.5.2",
+    # Upper bound: woollama-core is pre-1.0 and fast-moving — cap the minor so a
+    # breaking `complete()` change can't silently land. (A contract test guards the
+    # signature within the allowed range; see tests/test_woollama_provider.py.)
+    "woollama-core>=0.5.2,<0.6",
 ]
 
 [project.optional-dependencies]

--- a/src/lackpy/infer/providers/woollama.py
+++ b/src/lackpy/infer/providers/woollama.py
@@ -12,6 +12,12 @@ One ``model`` string of the form ``"<provider>/<model>"`` (e.g.
 woollama-known backend — so lackpy gets multi-provider model management without
 maintaining a provider per vendor. Implements the same ``InferenceProvider``
 protocol (``name`` / ``available`` / ``generate``) as the other tiers.
+
+Sampling and context knobs flow through from config: ``options`` carries
+ollama-native fields (notably ``num_ctx``, which routes the turn to the native
+``/api/chat`` endpoint that honors it), and ``params`` carries OpenAI top-level
+fields (e.g. ``max_tokens``, ``top_p``). ``temperature`` is managed here (a higher
+``retry_temperature`` is used on a correction pass).
 """
 from __future__ import annotations
 
@@ -21,12 +27,17 @@ from ..prompt import build_system_prompt
 class WoollamaProvider:
     def __init__(self, model: str = "ollama/qwen2.5-coder:1.5b",
                  temperature: float = 0.2, retry_temperature: float = 0.6,
-                 api_key: str | None = None, base_url: str | None = None) -> None:
+                 api_key: str | None = None, base_url: str | None = None,
+                 options: dict | None = None, params: dict | None = None) -> None:
         self._model = model
         self._temperature = temperature
         self._retry_temperature = retry_temperature
         self._api_key = api_key
         self._base_url = base_url
+        # ollama-native knobs (e.g. num_ctx — setting it routes ollama/* to the
+        # native /api/chat path); and extra OpenAI top-level fields (e.g. max_tokens).
+        self._options = options
+        self._params = params
 
     @property
     def name(self) -> str:
@@ -70,10 +81,12 @@ class WoollamaProvider:
             ]
 
         temperature = self._retry_temperature if is_retry else self._temperature
+        # temperature (with retry override) wins over any temperature in config params.
+        call_params = {**(self._params or {}), "temperature": temperature}
         try:
             content = await complete(
                 self._model, messages,
-                params={"temperature": temperature},
+                options=self._options, params=call_params,
                 api_key=self._api_key, base_url=self._base_url)
             self._last_output = content.strip() if content else None
             return self._last_output

--- a/src/lackpy/service.py
+++ b/src/lackpy/service.py
@@ -232,6 +232,8 @@ class LackpyService:
                     retry_temperature=provider_cfg.get("retry_temperature", 0.6),
                     api_key=provider_cfg.get("api_key"),
                     base_url=provider_cfg.get("base_url"),
+                    options=provider_cfg.get("options"),
+                    params=provider_cfg.get("params"),
                 ))
             elif plugin == "cascade" and name not in ("templates", "rules"):
                 from .infer.providers.cascade import CascadeProvider

--- a/tests/test_woollama_provider.py
+++ b/tests/test_woollama_provider.py
@@ -55,6 +55,44 @@ async def test_per_call_key_and_base_url_forwarded(calls):
     assert call["kw"]["api_key"] == "sk-x" and call["kw"]["base_url"] == "http://proxy/v1"
 
 
+async def test_options_and_params_forwarded(calls):
+    # options (ollama-native, e.g. num_ctx) + params (OpenAI top-level) flow through;
+    # the provider's temperature is merged into params and wins.
+    p = WoollamaProvider(model="ollama/m", temperature=0.2,
+                         options={"num_ctx": 8192}, params={"max_tokens": 256})
+    await p.generate("x", "ns")
+    call = calls[-1]
+    assert call["kw"]["options"] == {"num_ctx": 8192}
+    assert call["kw"]["params"] == {"max_tokens": 256, "temperature": 0.2}
+
+
+async def test_complete_accepts_lackpy_kwargs():
+    """Guard the real woollama.core.complete contract lackpy depends on.
+
+    woollama-core is pre-1.0 and fast-moving, AND it's a compiled (Rust/pyo3)
+    extension — so `inspect`-based signature checks don't work and the mocked tests
+    above (which use a `**kw`-swallowing fake) would miss a breaking change. Instead
+    we CALL the real function exactly as the provider does, against an unreachable
+    endpoint: it must return an awaitable and fail on TRANSPORT, not reject a kwarg
+    with TypeError. Runs in CI (woollama-core is a core dependency); fails loudly on
+    drift in the (model, messages, options, params, api_key, base_url) contract.
+    """
+    import inspect
+
+    core = pytest.importorskip("woollama.core")
+    coro = core.complete(
+        "ollama/contract-probe", [{"role": "user", "content": "x"}],
+        options={"num_ctx": 8}, params={"temperature": 0},
+        api_key=None, base_url="http://127.0.0.1:9/v1",   # unreachable → transport error
+    )
+    assert inspect.isawaitable(coro), "complete(...) must return an awaitable (lackpy awaits it)"
+    with pytest.raises(Exception) as excinfo:
+        await coro
+    assert not isinstance(excinfo.value, TypeError), (
+        f"woollama.core.complete rejected a kwarg lackpy passes: {excinfo.value}"
+    )
+
+
 def test_woollama_plugin_registered_from_config(tmp_path):
     """The `woollama` plugin wires a WoollamaProvider into the service's inference
     tiers (config-driven, alongside the deterministic templates/rules tiers)."""


### PR DESCRIPTION
## Harden + complete the woollama integration

Acts on the top two findings from the woollama-integration review: the seam is clean, but the implementation had robustness and completeness gaps. (Leaves error-propagation and the `base_url`/`/v1` leak as smaller follow-ups.)

### Completeness — config-driven `options` / `params`
Before, `WoollamaProvider` only ever sent `params={"temperature": …}`, so most of `woollama.core.complete()`'s surface was unreachable:
- **`num_ctx` was never set → the ollama-native `/api/chat` path was never taken.** Every `ollama/*` call went through OpenAI-compat `/v1` regardless, despite the docstring advertising native `num_ctx`.
- No `max_tokens` / `top_p` / etc.

Now `WoollamaProvider` accepts `options` (ollama-native) and `params` (OpenAI top-level), threaded from config:
```toml
[inference.providers.local]
plugin = "woollama"
model = "ollama/qwen2.5-coder:3b"
options = { num_ctx = 8192 }      # routes through native /api/chat
params  = { max_tokens = 512 }
```
`temperature` is still managed by the provider (with the retry override) and wins over any `params` temperature. Documented in `config.toml.example`; docstring corrected.

### Robustness — version cap + a *real* contract test
- **Cap the Alpha dep:** `woollama-core>=0.5.2,<0.6` — a breaking `complete()` change can't silently land.
- **Call-based contract test.** `woollama.core` is a compiled **Rust/pyo3** extension, so `inspect`-based signature checks don't work (my first attempt failed on exactly this), and the mocked unit tests use a `**kw`-swallowing fake that would miss a breaking change. The new test **calls the real `complete()`** as the provider does, against an unreachable endpoint, and asserts it returns an awaitable and fails on *transport*, not by rejecting a kwarg. It runs in CI (woollama-core is a core dep) and fails loudly on contract drift.
- This also closed a real gap: lackpy's actual `await complete(...)` usage had **never** been exercised against the real extension — only imported. Now verified green against the freshly-released **woollama-core 0.5.3** (which the `<0.6` cap correctly allowed).

### Tests
- `test_options_and_params_forwarded` — knobs forwarded; temperature merged + wins.
- `test_complete_accepts_lackpy_kwargs` — real-contract guard (awaitable + kwargs accepted).
- Full suite: **619 passed, 23 skipped** (CI-faithful venv with woollama-core from PyPI).

Note: no version bump here — `pyproject` stays at the already-published 0.12.0; bump at release time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
