### PR TITLE
fix(woollama): log backend failures instead of swallowing them

### DIFF
--- a/src/lackpy/infer/providers/woollama.py
+++ b/src/lackpy/infer/providers/woollama.py
@@ -21,7 +21,11 @@ fields (e.g. ``max_tokens``, ``top_p``). ``temperature`` is managed here (a high
 """
 from __future__ import annotations
 
+import logging
+
 from ..prompt import build_system_prompt
+
+logger = logging.getLogger(__name__)
 
 
 class WoollamaProvider:
@@ -90,7 +94,14 @@ class WoollamaProvider:
                 api_key=self._api_key, base_url=self._base_url)
             self._last_output = content.strip() if content else None
             return self._last_output
-        except Exception:
+        except Exception as e:
+            # Returning None hands control to the next tier, but the *reason* must
+            # not vanish: a misconfigured backend (bad model string, missing key,
+            # unreachable host) otherwise surfaces only as the dispatcher's generic
+            # "all providers failed". woollama raises InferenceError with a useful
+            # kind/status/message; log it so the failure is diagnosable.
+            logger.warning("woollama.core.complete failed (model=%r): %s: %s",
+                           self._model, type(e).__name__, e)
             self._last_output = None
             return None
 

--- a/tests/test_woollama_provider.py
+++ b/tests/test_woollama_provider.py
@@ -66,6 +66,25 @@ async def test_options_and_params_forwarded(calls):
     assert call["kw"]["params"] == {"max_tokens": 256, "temperature": 0.2}
 
 
+async def test_backend_error_is_logged_not_silently_swallowed(monkeypatch, caplog):
+    # A failed backend call still returns None (control passes to the next tier),
+    # but the reason must be logged — not vanish into "all providers failed".
+    import logging
+
+    import woollama.core as wc
+
+    async def boom_complete(model, messages, **kw):
+        raise RuntimeError("connection refused")
+
+    monkeypatch.setattr(wc, "complete", boom_complete)
+    p = WoollamaProvider(model="ollama/m")
+    with caplog.at_level(logging.WARNING):
+        out = await p.generate("count rows", "ns")
+    assert out is None
+    assert "woollama.core.complete failed" in caplog.text
+    assert "connection refused" in caplog.text
+
+
 async def test_complete_accepts_lackpy_kwargs():
     """Guard the real woollama.core.complete contract lackpy depends on.
 


### PR DESCRIPTION
Follow-up #2 from the woollama integration review (error-swallowing).

`WoollamaProvider` caught all exceptions from `woollama.core.complete` and returned `None`. The dispatcher does `if raw is None: continue`, so a misconfigured backend (bad model, missing key, unreachable host) disappeared into the generic "all providers failed" — woollama wasn't even recorded in `errors_by_provider`.

Now the provider logs the exception (type + message; woollama's `InferenceError` carries kind/status/message) at WARNING before returning `None` — diagnosable, with no change to tier-fallthrough behavior. Test asserts `generate` still returns `None` and the reason is logged.

Suite: 620 passed, 23 skipped. (Leaves the `base_url`/`v1` config-leak follow-up — it needs a small UX decision.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)