### PR TITLE
fix(kit): actionable error when a kit references an unprovided tool (#5)

### DIFF
--- a/src/lackpy/kit/registry.py
+++ b/src/lackpy/kit/registry.py
@@ -126,7 +126,13 @@ def _resolve_tool_names(tool_names: list[str], alias_names: list[str], toolbox: 
     tool_docs: list[str] = []
     for alias, name in zip(alias_names, tool_names):
         if name not in toolbox.tools:
-            raise KeyError(f"Unknown tool: '{name}'")
+            available = sorted(toolbox.tools)
+            shown = ", ".join(available[:20]) + (" …" if len(available) > 20 else "")
+            raise KeyError(
+                f"Unknown tool {name!r}: no configured source provides it. Tools come "
+                f"from builtins, config [[tools]], or an MCP server — confirm the kit's "
+                f"names match a configured source. Available now: {shown or '(none)'}"
+            )
         spec = toolbox.tools[name]
         tools[alias] = spec
         callables[alias] = toolbox.resolve(name)

--- a/tests/kit/test_registry.py
+++ b/tests/kit/test_registry.py
@@ -29,8 +29,14 @@ class TestResolveFromList:
         assert kit.grade.w == 1
 
     def test_unknown_tool_in_list_raises(self, toolbox):
-        with pytest.raises(KeyError):
+        with pytest.raises(KeyError) as ei:
             resolve_kit(["read_file", "nonexistent"], toolbox)
+        # Actionable failure: names the tool, explains where tools come from, and
+        # lists what's available — not a bare "Unknown tool".
+        msg = str(ei.value)
+        assert "nonexistent" in msg
+        assert "configured source" in msg
+        assert "read_file" in msg          # available tools surfaced
 
 
 class TestResolveFromName:


### PR DESCRIPTION
Partial fix for #5. Resolving a kit whose tools aren't in the toolbox raised a bare `KeyError("Unknown tool: 'select'")`. Now the error names the tool, explains where tools come from (builtins / config `[[tools]]` / MCP), and lists what's available.

**Honest scope:** this fixes the *failure mode*, not the root of #5. Investigation showed `pluckit.kit` ships in `.lackpy/kits/` but its tools exist only as **test-only mocks** (`PLUCKIT_TOOLS`, `provider="mock"`, registered only in tests) with **no production source** — so `--kit pluckit` can't resolve in a real workspace. Registering the mock in production (the obvious-looking fix) would inject fake no-op tools, which is worse. Making pluckit actually work is a product decision (wire a real squackit MCP source, or treat `pluckit.kit` as a demo) — left for that call.

Suite: 620 passed, 23 skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)