### PR TITLE
docs: correct inference tiers + router framing (woollama, not Rust cosmic-fabric)

### DIFF
--- a/docs/concepts/architecture.md
+++ b/docs/concepts/architecture.md
@@ -27,8 +27,9 @@ source-populated toolbox above):
   │     ──► InferenceDispatcher                                    │
   │          tier 0: TemplatesProvider (regex pattern match)       │
   │          tier 1: RulesProvider    (keyword rules)              │
-  │          tier 2: OllamaProvider   (local LLM, optional)        │
-  │          tier 3: AnthropicProvider (cloud LLM, optional)       │
+  │          tier 2: WoollamaProvider (LLM via woollama-core;      │
+  │                  ollama/anthropic/openai by "<provider>/<m>")  │
+  │          tier —: CascadeProvider  (raw-completion, optional)   │
   │     ◄── GenerationResult (program + provider_name + time_ms)  │
   │                                                                │
   │  3. Validation                                                 │

--- a/docs/design/direction.md
+++ b/docs/design/direction.md
@@ -41,18 +41,26 @@ The "literate" style — the agent writes a markdown-style document that is rend
 as it executes, then the rendered result is opened (e.g. via `xdg-open`) — is
 considered valuable on its own, not just a presentation mode.
 
-## Integration: cosmic-fabric
+## Integration: woollama (and cosmic-fabric)
 
-lackpy is meant to plug into **cosmic-fabric** (`cosmic-fabricd`), a canonical Rust
-router that handles several routes to an inferencer consistently:
+!!! note "Updated 2026-06 — the router is woollama, not a Rust cosmic-fabric"
+    The original direction named **cosmic-fabric** as a *canonical Rust router with no
+    Python dependencies*. That isn't how it landed: the router is **woollama** — a
+    Python/FastAPI daemon (OpenAI-compatible + MCP) — and cosmic-fabric is a Python
+    daemon + Rust *UI* that is itself a **client** of woollama. The integration intent
+    below still holds; only which component plays "router" changed.
 
-- cosmic-fabric is the canonical router and must have **no Python dependencies**.
-- lackpy is invoked as a **subprocess** (for now) or **via its MCP server** — not
-  linked in. The handoff seam is lackpy's **`delegate` tool**; lackpy may also
-  expose its templates.
-- lackpy works with both cosmic-fabric and raw Ollama. Tools handed across the seam
-  should carry full specs (params, docs), and lackpy-specific terminology (e.g.
-  "kit") should not bleed into cosmic-fabric.
+- **woollama is the model-routing substrate.** lackpy already embeds `woollama.core`
+  (the `WoollamaProvider` inference tier) for its model calls — multi-provider routing
+  via a `"<provider>/<model>"` string, so lackpy does no per-vendor HTTP itself.
+- **lackpy plugs into an orchestrator via the `delegate` seam.** It is invoked as a
+  **subprocess** (for now) or **via its MCP server** — not linked in. The handoff is
+  lackpy's `delegate` tool; lackpy may also expose its templates.
+- **lackpy works with woollama and with raw Ollama.** Tools handed across the seam
+  should carry full specs (params, docs), and lackpy-specific terminology (e.g. "kit")
+  should not bleed into the orchestrator.
+- **cosmic-fabric is a *peer* consumer of woollama** (a desktop frontend), not lackpy's
+  router — a sibling integration, not a dependency.
 
 ## Model choice is local, not a default
 


### PR DESCRIPTION
From the docs/plans review. Two stale spots:

- **`concepts/architecture.md`** — the inference-pipeline ASCII still showed retired `tier 2: OllamaProvider` / `tier 3: AnthropicProvider`; now `WoollamaProvider` + optional `CascadeProvider`. (Component table was fixed in #15; this diagram was missed.)
- **`design/direction.md`** — the integration section called cosmic-fabric a "canonical Rust router with no Python dependencies." Corrected: **woollama** (Python/FastAPI) is the router; cosmic-fabric is a Python daemon + Rust *UI* that's a *client* of it. Kept the original intent (delegate seam, full tool specs, no "kit" bleed); cosmic-fabric reframed as a peer consumer.

Content-only edits to existing pages. (Local `mkdocs --strict` couldn't run — the working venv lost its lackpy install after a restart, an env issue unrelated to this change; reproduces on `main`. RTD builds with the package installed.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)