### PR TITLE
feat(profiles): Phase 1 — Profile + resolve_profile (RFC 0002 incr. 5)

### DIFF
--- a/src/lackpy/config.py
+++ b/src/lackpy/config.py
@@ -30,6 +30,9 @@ class LackpyConfig:
     mcp_servers: dict[str, dict[str, Any]] = field(default_factory=dict)
     mcp_host_configs: list[str] = field(default_factory=list)
     virtual_tools: list[dict[str, Any]] = field(default_factory=list)
+    # [profiles.<name>] tables — named per-task bundles (tools + inference + language/
+    # execution + policy). Raw dicts here, like `tools`; parsed into Profile on resolve.
+    profiles: dict[str, dict[str, Any]] = field(default_factory=dict)
     config_dir: Path = field(default_factory=lambda: Path(".lackpy"))
 
 
@@ -50,6 +53,7 @@ def load_config(workspace: Path | None = None) -> LackpyConfig:
     mcp_servers = data.get("mcp_servers", {})
     mcp_host_configs = data.get("mcp", {}).get("host_configs", [])
     virtual_tools = data.get("virtual_tools", [])
+    profiles = data.get("profiles", {})
     providers: dict[str, dict[str, Any]] = {}
     for name, cfg in inference.get("providers", {}).items():
         providers[name] = cfg
@@ -66,5 +70,6 @@ def load_config(workspace: Path | None = None) -> LackpyConfig:
         mcp_servers=mcp_servers,
         mcp_host_configs=mcp_host_configs,
         virtual_tools=virtual_tools,
+        profiles=profiles,
         config_dir=config_dir,
     )

--- a/src/lackpy/profiles.py
+++ b/src/lackpy/profiles.py
@@ -1,0 +1,159 @@
+"""Profiles — named per-task config bundles (RFC 0002 increment 5).
+
+A *profile* generalizes a "kit": instead of selecting only tools, it bundles, per task, a
+tool selection + inference config (model/mode/…) + which language/execution model +
+optional policy defaults. A **kit is the degenerate profile** that sets only ``tools``.
+
+Thin by design (maintainer's decision): a ``Profile`` is a bundle of *references*, and
+resolving it **composes existing machinery** — the tool selection goes through the
+unchanged ``resolve_kit`` (so grade/policy/validation are untouched), and the rest is
+carried alongside. Resolution yields a ``ResolvedProfile`` that is **driver-agnostic**
+(one-shot, incremental, conversation, eventful, … all consume it — RFC §3.6) and never
+assumes a single synchronous call; results flow through the emit seam
+(:mod:`lackpy.run.events`), not an assumed return value.
+
+Phase 1 is purely additive: this does not touch the existing kit/service call sites.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from .kit.registry import ResolvedKit, resolve_kit
+from .kit.toolbox import Toolbox
+from .lang.grader import Grade
+
+DEFAULT_LANGUAGE = "restricted-python"
+DEFAULT_EXECUTION = "one-shot"
+
+# Recognized [profiles.<name>] keys — anything else is rejected so typos surface early.
+_PROFILE_KEYS = frozenset({
+    "tools", "extra_tools", "model", "mode", "order", "temperature",
+    "rules", "language", "execution", "sandbox", "policy",
+})
+
+
+@dataclass(frozen=True)
+class Profile:
+    """A named per-task config bundle (the *input*). Thin: references, not resolved state.
+
+    Every field is optional; a profile that sets only ``tools`` is the degenerate "kit".
+    Inference fields left ``None`` fall back to the service config at resolve time
+    (so an unset profile costs nothing — invariant 8). ``language``/``execution`` are the
+    two interpreter axes (RFC §3.5); their defaults are today's only supported path.
+    """
+
+    tools: str | list[str] | dict[str, Any] | None = None
+    extra_tools: list[str] | None = None
+    # inference (service-global today → per-profile here)
+    model: str | None = None
+    mode: str | None = None
+    order: list[str] | None = None
+    temperature: float | None = None
+    rules: list[str] | None = None
+    # interpreter axes (RFC §3.5): language profile × execution model
+    language: str = DEFAULT_LANGUAGE
+    execution: str = DEFAULT_EXECUTION
+    sandbox: str | None = None
+    policy: dict[str, Any] | None = None
+
+    @classmethod
+    def from_config(cls, data: dict[str, Any]) -> "Profile":
+        """Build a Profile from a ``[profiles.<name>]`` config table (raw dict)."""
+        unknown = set(data) - _PROFILE_KEYS
+        if unknown:
+            raise ValueError(
+                f"unknown profile key(s): {sorted(unknown)}; allowed: {sorted(_PROFILE_KEYS)}"
+            )
+        return cls(**{k: data[k] for k in _PROFILE_KEYS if k in data})
+
+
+@dataclass
+class ResolvedProfile:
+    """A resolved profile — a driver-agnostic, session-able unit.
+
+    Holds the resolved tools (the existing ``ResolvedKit``, with its tool-derived grade)
+    plus the carried inference/language/execution/policy selections. Drivers consume this;
+    nothing here assumes a single synchronous call (invariant 9).
+    """
+
+    tools: ResolvedKit
+    model: str | None = None
+    mode: str | None = None
+    order: list[str] | None = None
+    temperature: float | None = None
+    rules: list[str] | None = None
+    language: str = DEFAULT_LANGUAGE
+    execution: str = DEFAULT_EXECUTION
+    sandbox: str | None = None
+    policy: dict[str, Any] | None = None
+
+    # A profile's grade/description ARE its tools' — never independently set (invariant 3).
+    @property
+    def grade(self) -> Grade:
+        return self.tools.grade
+
+    @property
+    def description(self) -> str:
+        return self.tools.description
+
+
+def resolve_profile(
+    profile: "Profile | str | list[str] | dict[str, Any] | None",
+    toolbox: Toolbox,
+    *,
+    profiles: dict[str, dict[str, Any]] | None = None,
+    kits_dir: Path | None = None,
+    defaults: dict[str, Any] | None = None,
+) -> ResolvedProfile:
+    """Resolve a profile into a ``ResolvedProfile``, composing the unchanged ``resolve_kit``.
+
+    ``profile`` may be:
+
+    - a ``Profile`` — used as-is;
+    - a ``str`` naming a ``[profiles.<name>]`` entry in ``profiles`` — expanded;
+    - any tool-selection value (``str`` tool/tool-set name, ``list``, ``dict``, ``None``) —
+      treated as the **degenerate, tools-only profile** ("a kit is a profile").
+
+    Inference fields the profile leaves unset fall back to ``defaults`` (the service config).
+    Tool resolution, grade, policy, and validation go through the existing machinery
+    untouched.
+    """
+    prof = _coerce(profile, profiles)
+    resolved_tools = resolve_kit(
+        prof.tools, toolbox, kits_dir=kits_dir, extra_tools=prof.extra_tools
+    )
+    d = defaults or {}
+
+    def _or_default(value: Any, key: str) -> Any:
+        return value if value is not None else d.get(key)
+
+    return ResolvedProfile(
+        tools=resolved_tools,
+        model=_or_default(prof.model, "model"),
+        mode=_or_default(prof.mode, "mode"),
+        order=_or_default(prof.order, "order"),
+        temperature=_or_default(prof.temperature, "temperature"),
+        rules=prof.rules,
+        language=prof.language,
+        execution=prof.execution,
+        sandbox=_or_default(prof.sandbox, "sandbox"),
+        policy=prof.policy,
+    )
+
+
+def _coerce(
+    profile: "Profile | str | list[str] | dict[str, Any] | None",
+    profiles: dict[str, dict[str, Any]] | None,
+) -> Profile:
+    """Normalize the ``profile`` argument to a ``Profile``.
+
+    A ``str`` that names a configured profile expands to it; any other value is a bare
+    tool selection → the degenerate, tools-only profile.
+    """
+    if isinstance(profile, Profile):
+        return profile
+    if isinstance(profile, str) and profiles and profile in profiles:
+        return Profile.from_config(profiles[profile])
+    return Profile(tools=profile)

--- a/src/lackpy/run/events.py
+++ b/src/lackpy/run/events.py
@@ -1,0 +1,42 @@
+"""The emit/event seam for profile execution.
+
+A profile (see :mod:`lackpy.profiles`) is **lifecycle-decoupled**: the same profile is
+run by different *drivers* — one-shot, incremental/literate, conversation, eventful,
+scheduled, parallel (see RFC 0002 increment 5, §3.6). Several of those drivers need the
+run to **emit** results *as it goes* — a rendered cell, a partial result, a tool-call
+record, a notification — not only return a final value.
+
+This module defines that channel as a tiny, driver-agnostic seam:
+
+- ``ExecutionEvent`` — one emitted unit (kind + data + optional index).
+- ``Emit`` — a callable a driver provides; the runtime calls it per event.
+
+It is intentionally minimal and **not yet wired** into ``RestrictedRunner`` /
+``ExecutionResult``. It exists so the profile/execution contract is emit-capable from
+the start (a one-shot driver simply passes no emitter and reads the return value;
+literate/conversation/eventful drivers pass one and stream events). Wiring lands with
+the drivers, not in the additive profile-model phase.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable
+
+
+@dataclass
+class ExecutionEvent:
+    """One unit emitted during a profile run.
+
+    ``kind`` is an open string (e.g. ``"cell"``, ``"tool_call"``, ``"partial"``,
+    ``"notify"``, ``"final"``) so new drivers can introduce event kinds without
+    changing this type. ``index`` orders events within a session (e.g. cell index).
+    """
+
+    kind: str
+    data: Any = None
+    index: int | None = None
+
+
+#: A driver-provided sink. The runtime calls it once per ``ExecutionEvent``. ``None``
+#: means "no emission" — the one-shot path, where the return value is the whole result.
+Emit = Callable[[ExecutionEvent], None]

--- a/tests/lang/test_no_upward_deps.py
+++ b/tests/lang/test_no_upward_deps.py
@@ -13,7 +13,7 @@ import lackpy.lang
 
 LANG_DIR = Path(lackpy.lang.__file__).parent
 FORBIDDEN = {"run", "kit", "policy", "infer", "service", "lackey", "prompts",
-             "interpreters", "mcp", "sources"}
+             "interpreters", "mcp", "sources", "profiles"}
 
 
 def _imported_modules(py: Path):

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -1,0 +1,121 @@
+"""Phase 1 — Profile / resolve_profile (RFC 0002 increment 5, additive).
+
+Covers the core promise: a profile composes the existing resolve_kit (a kit is the
+degenerate, tools-only profile), carries per-task inference + the language/execution
+axes, falls back to service defaults, and parses from [profiles.<name>] config.
+"""
+from __future__ import annotations
+
+import pytest
+
+from lackpy.config import load_config
+from lackpy.kit.providers.builtin import BuiltinProvider
+from lackpy.kit.registry import resolve_kit
+from lackpy.kit.toolbox import ArgSpec, ToolSpec, Toolbox
+from lackpy.profiles import Profile, ResolvedProfile, resolve_profile
+
+
+@pytest.fixture
+def toolbox():
+    tb = Toolbox()
+    tb.register_provider(BuiltinProvider())
+    for name, desc, grade in [("read_file", "Read file", 1), ("find_files", "Find files", 1),
+                              ("edit_file", "Edit file", 3)]:
+        tb.register_tool(ToolSpec(
+            name=name, provider="builtin", description=desc,
+            args=[ArgSpec(name="path", type="str")],
+            returns="str", grade_w=grade, effects_ceiling=grade,
+        ))
+    return tb
+
+
+class TestDegenerate:
+    def test_tools_only_profile_equals_a_kit(self, toolbox):
+        # The core invariant: a tools-only profile resolves to exactly what resolve_kit does.
+        rp = resolve_profile(["read_file", "find_files"], toolbox)
+        rk = resolve_kit(["read_file", "find_files"], toolbox)
+        assert isinstance(rp, ResolvedProfile)
+        assert set(rp.tools.tools) == set(rk.tools)
+        assert rp.grade == rk.grade                 # grade passthrough = the tools' grade
+        assert rp.description == rk.description
+        assert rp.language == "restricted-python"   # axis defaults — today's path
+        assert rp.execution == "one-shot"
+        assert rp.model is None and rp.mode is None  # nothing carried, nothing defaulted
+
+    def test_none_string_is_empty(self, toolbox):
+        rp = resolve_profile("none", toolbox)
+        assert rp.tools.tools == {}
+
+    def test_extra_tools_merged_and_grade_raised(self, toolbox):
+        rp = resolve_profile(Profile(tools=["read_file"], extra_tools=["edit_file"]), toolbox)
+        assert set(rp.tools.tools) == {"read_file", "edit_file"}
+        assert rp.grade.w == 3                       # edit_file (3/3) raises the join
+
+
+class TestInferenceCarry:
+    def test_profile_object_carries_inference_and_axes(self, toolbox):
+        rp = resolve_profile(
+            Profile(tools=["read_file"], model="ollama/qwen2.5-coder:3b", mode="spm",
+                    language="shlack", execution="literate"),
+            toolbox,
+        )
+        assert rp.model == "ollama/qwen2.5-coder:3b"
+        assert rp.mode == "spm"
+        assert rp.language == "shlack"
+        assert rp.execution == "literate"
+
+    def test_defaults_fallback_and_profile_wins(self, toolbox):
+        defaults = {"model": "default/model", "mode": "1-shot"}
+        # unset → falls back to defaults
+        rp = resolve_profile(Profile(tools=["read_file"]), toolbox, defaults=defaults)
+        assert rp.model == "default/model" and rp.mode == "1-shot"
+        # set → profile wins over the default
+        rp2 = resolve_profile(Profile(tools=["read_file"], model="prof/model"), toolbox,
+                              defaults=defaults)
+        assert rp2.model == "prof/model" and rp2.mode == "1-shot"
+
+
+class TestByName:
+    def test_resolve_named_profile_from_registry(self, toolbox):
+        profiles = {"fast": {"tools": ["read_file", "find_files"],
+                             "model": "ollama/qwen2.5-coder:3b", "mode": "1-shot"}}
+        rp = resolve_profile("fast", toolbox, profiles=profiles)
+        assert set(rp.tools.tools) == {"read_file", "find_files"}
+        assert rp.model == "ollama/qwen2.5-coder:3b" and rp.mode == "1-shot"
+
+    def test_str_not_a_named_profile_is_a_toolset(self, toolbox):
+        # A str that isn't a configured profile is a bare tool-set value → resolve_kit
+        # treats it as a kit/profile file name (here: missing → FileNotFoundError).
+        with pytest.raises(FileNotFoundError):
+            resolve_profile("not-a-profile", toolbox, profiles={"fast": {}}, kits_dir=None)
+
+
+class TestFromConfig:
+    def test_valid_table(self):
+        p = Profile.from_config({"tools": ["read_file"], "model": "m", "execution": "literate"})
+        assert p.tools == ["read_file"] and p.model == "m" and p.execution == "literate"
+        assert p.language == "restricted-python"     # default for unset axis
+
+    def test_unknown_key_raises(self):
+        with pytest.raises(ValueError, match="unknown profile key"):
+            Profile.from_config({"toolz": ["read_file"]})
+
+
+def test_config_parses_profiles_table(tmp_path):
+    cfg_file = tmp_path / ".lackpy" / "config.toml"
+    cfg_file.parent.mkdir()
+    cfg_file.write_text('''
+[profiles.fast]
+tools = ["read_file", "find_files"]
+model = "ollama/qwen2.5-coder:3b"
+mode  = "1-shot"
+
+[profiles.notebook]
+tools     = "filesystem"
+language  = "shlack"
+execution = "literate"
+''')
+    cfg = load_config(tmp_path)
+    assert "fast" in cfg.profiles and "notebook" in cfg.profiles
+    assert cfg.profiles["fast"]["model"] == "ollama/qwen2.5-coder:3b"
+    assert cfg.profiles["notebook"]["execution"] == "literate"


### PR DESCRIPTION
**Phase 1 of the kits→profiles design** ([draft #26](https://github.com/teaguesterling/lackpy/pull/26) / `docs/design/kits-to-profiles.md`). Purely **additive** — touches no existing kit/service call site; a kit stays a kit, this adds the profile layer that *composes* it.

### What lands
- **`lackpy.profiles`** — `Profile` (thin, frozen input bundle: tools + inference (`model`/`mode`/`order`/`temperature`) + the two interpreter axes (`language` × `execution`, defaulted `restricted-python` × `one-shot`) + `sandbox`/`policy`/`rules`), `Profile.from_config` (parses a `[profiles.<name>]` table, rejects unknown keys), and **`resolve_profile()`** which composes the **unchanged `resolve_kit`** for tools (so grade/policy/validation are untouched — *a kit is the degenerate, tools-only profile*) and carries the rest with service-config fallback for unset inference fields. Returns `ResolvedProfile`, a **driver-agnostic, session-able** unit whose grade/description ARE its tools' (invariant 3); nothing assumes one synchronous call (invariant 9).
- **`lackpy.run.events`** — the **emit/event seam** (`ExecutionEvent` + `Emit`), minimal + documented + **not yet wired**, so the contract is emit-capable from the start (one-shot passes no emitter; literate/conversation/eventful drivers stream events — RFC §3.6).
- **`config`** parses `[profiles.<name>]` into `LackpyConfig.profiles`.
- **leaf-guard** adds `profiles` to `FORBIDDEN` (lang stays pure — invariant 5).

### Decisions it encodes (from #26)
thin (references, not a fat resolved object) · config tables · two interpreter axes · lifecycle-decoupled + emit-capable contract.

### Tests
degenerate profile == a kit; inference carry + defaults fallback; resolve-by-name; `from_config` validation; `[profiles.*]` parsing; the language/execution axes. **656 passed, 12 skipped.**

Holding for your review — this commits the `Profile` type shape. Later phases (per #26 §8): wire per-profile inference into the service, `profile=` public param (hard-replacing `kit=`), CLI/MCP, then retire "kit".

🤖 Generated with [Claude Code](https://claude.com/claude-code)