### PR TITLE
feat(profiles): Phase 2 — per-profile inference + drop _model reflection

### DIFF
--- a/src/lackpy/infer/providers/woollama.py
+++ b/src/lackpy/infer/providers/woollama.py
@@ -43,6 +43,22 @@ class WoollamaProvider:
         self._options = options
         self._params = params
 
+    def with_overrides(self, *, model: str | None = None,
+                       temperature: float | None = None) -> "WoollamaProvider":
+        """Return a copy with ``model``/``temperature`` overridden (others preserved).
+
+        Lets a profile select a per-task model/temperature without rebuilding the
+        provider from config — the service swaps the LLM tier for this clone on calls
+        that override, and uses the original (this instance) otherwise.
+        """
+        return WoollamaProvider(
+            model=model or self._model,
+            temperature=temperature if temperature is not None else self._temperature,
+            retry_temperature=self._retry_temperature,
+            api_key=self._api_key, base_url=self._base_url,
+            options=self._options, params=self._params,
+        )
+
     @property
     def name(self) -> str:
         return "woollama"

--- a/src/lackpy/service.py
+++ b/src/lackpy/service.py
@@ -104,6 +104,9 @@ class LackpyService:
         for source, precedence in self._build_tool_sources():
             self.toolbox.add_source(source, precedence)
         self._inference_providers: list = []
+        # The configured LLM model (set by _init_inference_providers from the woollama
+        # tier) — recorded explicitly instead of reflecting `getattr(p, "_model")`.
+        self._llm_model: str | None = None
         self._init_inference_providers()
         self._policy = PolicyLayer()
         self._policy.add_source(KitPolicySource(self.toolbox))
@@ -226,8 +229,10 @@ class LackpyService:
                 # woollama-known backend (ollama, anthropic, openai, …) via a
                 # "<provider>/<model>" string — lackpy stops doing per-vendor HTTP.
                 from .infer.providers.woollama import WoollamaProvider
+                model = provider_cfg.get("model", "ollama/qwen2.5-coder:1.5b")
+                self._llm_model = model  # recorded for PolicyContext (no _model reflection)
                 self._inference_providers.append(WoollamaProvider(
-                    model=provider_cfg.get("model", "ollama/qwen2.5-coder:1.5b"),
+                    model=model,
                     temperature=provider_cfg.get("temperature", 0.2),
                     retry_temperature=provider_cfg.get("retry_temperature", 0.6),
                     api_key=provider_cfg.get("api_key"),
@@ -241,6 +246,22 @@ class LackpyService:
                     host=provider_cfg.get("host", "http://localhost:11434"),
                     tiers=provider_cfg.get("tiers"),
                 ))
+
+    def _providers_for(self, model: str | None, temperature: float | None) -> list:
+        """The inference providers for one call, applying a per-call model/temperature.
+
+        No override → the shared global list (zero allocation, identical behavior —
+        invariant 8). With an override → a copy where each tier that supports it (the
+        woollama LLM tier, via ``with_overrides``) is cloned to the requested
+        model/temperature; deterministic tiers (templates/rules) pass through unchanged.
+        """
+        if model is None and temperature is None:
+            return self._inference_providers
+        return [
+            p.with_overrides(model=model, temperature=temperature)
+            if hasattr(p, "with_overrides") else p
+            for p in self._inference_providers
+        ]
 
     def _init_kibitzer(self) -> None:
         """Initialize Kibitzer session if available."""
@@ -352,7 +373,9 @@ class LackpyService:
     async def generate(self, intent: str, kit: str | list[str] | dict | None = None,
                        params: dict[str, Any] | None = None, rules: list | None = None,
                        mode: str | None = None, interpreter: Any = None,
-                       extra_tools: list[str] | None = None) -> GenerationResult:
+                       extra_tools: list[str] | None = None,
+                       model: str | None = None,
+                       temperature: float | None = None) -> GenerationResult:
         """Generate a lackpy program from a natural language intent.
 
         Args:
@@ -365,6 +388,11 @@ class LackpyService:
                 is forwarded to the prompt builder. When present, the inference
                 prompt uses interpreter-specialized framing instead of the
                 generic Jupyter-cell template.
+            model: Per-call LLM model override (``"<provider>/<model>"``). When set, the
+                woollama tier is cloned to this model for this call only; when omitted,
+                the service-configured model is used (identical to prior behavior). This
+                is how a profile selects a per-task model (RFC 0002 incr. 5).
+            temperature: Per-call temperature override for the LLM tier.
 
         Returns:
             A GenerationResult with the generated program and provider metadata.
@@ -378,12 +406,16 @@ class LackpyService:
         resolved = self._gate_kit(self._resolve_kit(kit, extra_tools=extra_tools))
         _, params_desc, param_names = self._resolve_params(params, resolved)
 
+        # Per-call providers: the global set, or a copy with the LLM tier's model/temperature
+        # overridden when the caller (a profile) supplies one. Omitted → identical to before.
+        providers = self._providers_for(model, temperature)
+
         effective_mode = mode or self._config.inference_mode
 
         if effective_mode and effective_mode in STRATEGIES:
             strategy_cls = STRATEGIES[effective_mode]
             strategy = strategy_cls()
-            dispatcher = InferenceDispatcher(providers=self._inference_providers)
+            dispatcher = InferenceDispatcher(providers=providers)
             # SPM needs an LLM provider (skip deterministic templates/rules)
             if effective_mode == "spm":
                 llm_providers = [p for p in dispatcher.get_providers()
@@ -413,17 +445,14 @@ class LackpyService:
             )
 
         # Default: legacy dispatcher path
-        dispatcher = InferenceDispatcher(providers=self._inference_providers)
+        dispatcher = InferenceDispatcher(providers=providers)
         allowed = set(resolved.tools.keys()) | param_names
 
-        # Resolve policy — kit baseline + optional kibitzer hints + optional umwelt
+        # Resolve policy — kit baseline + optional kibitzer hints + optional umwelt.
+        # The active model is known explicitly (per-call override or the configured LLM
+        # model) — no more reflecting `getattr(provider, "_model")`.
         from .policy.types import PolicyContext, ModelSpec
-        model_name = None
-        for p in dispatcher.get_providers():
-            m = getattr(p, "_model", None)
-            if m:
-                model_name = m
-                break
+        model_name = model or self._llm_model
         policy_context: PolicyContext = {"kit": resolved}
         if model_name:
             policy_context["model"] = ModelSpec(name=model_name)
@@ -515,7 +544,9 @@ class LackpyService:
                        _program_override: str | None = None,
                        mode: str | None = None,
                        interpreter: Any = None,
-                       extra_tools: list[str] | None = None) -> dict[str, Any]:
+                       extra_tools: list[str] | None = None,
+                       model: str | None = None,
+                       temperature: float | None = None) -> dict[str, Any]:
         """Generate and execute a program from a natural language intent in one step.
 
         Combines generate and run_program: generates a program from intent, then
@@ -560,7 +591,8 @@ class LackpyService:
             )
         else:
             gen_result = await self.generate(intent, kit, params, rules, mode=mode,
-                                            interpreter=interpreter, extra_tools=extra_tools)
+                                            interpreter=interpreter, extra_tools=extra_tools,
+                                            model=model, temperature=temperature)
 
         # Kibitzer: validate planned calls before execution
         kibitzer_suggestions: list[str] = []

--- a/tests/test_profiles_inference.py
+++ b/tests/test_profiles_inference.py
@@ -1,0 +1,68 @@
+"""Phase 2 — per-profile inference wiring (RFC 0002 incr. 5).
+
+The mechanism that lets a profile select a per-task model/temperature: ``generate``/
+``delegate`` take ``model``/``temperature`` overrides, the woollama LLM tier is cloned
+per call when one is set (omitted → the global list, unchanged — invariant 8), and the
+active model is recorded explicitly (no ``getattr(provider, "_model")`` reflection).
+"""
+from __future__ import annotations
+
+import pytest
+
+from lackpy.config import LackpyConfig
+from lackpy.infer.providers.woollama import WoollamaProvider
+from lackpy.profiles import Profile, resolve_profile
+from lackpy.service import LackpyService
+
+
+def test_with_overrides_clones_model_temp_preserves_rest():
+    p = WoollamaProvider(model="ollama/a", temperature=0.2, retry_temperature=0.7,
+                         api_key="k", base_url="u", options={"num_ctx": 8192},
+                         params={"max_tokens": 64})
+    q = p.with_overrides(model="ollama/b")
+    assert q._model == "ollama/b"
+    assert q._temperature == 0.2 and q._retry_temperature == 0.7   # preserved
+    assert q._api_key == "k" and q._base_url == "u"
+    assert q._options == {"num_ctx": 8192} and q._params == {"max_tokens": 64}
+    # temperature-only override keeps the model
+    r = p.with_overrides(temperature=0.9)
+    assert r._model == "ollama/a" and r._temperature == 0.9
+
+
+@pytest.fixture
+def svc(tmp_path):
+    cfg = LackpyConfig(
+        inference_order=["llm"],
+        inference_providers={"llm": {"plugin": "woollama", "model": "ollama/test-model"}},
+        config_dir=tmp_path / ".lackpy",
+    )
+    return LackpyService(workspace=tmp_path, config=cfg)
+
+
+def test_llm_model_recorded_at_init_no_reflection(svc):
+    # The configured model is captured explicitly — what PolicyContext now reads.
+    assert svc._llm_model == "ollama/test-model"
+
+
+def test_providers_for_identity_when_no_override(svc):
+    # Invariant 8: no override → the exact same global list, zero allocation.
+    assert svc._providers_for(None, None) is svc._inference_providers
+
+
+def test_providers_for_overrides_only_the_llm_tier(svc):
+    out = svc._providers_for("ollama/other", 0.5)
+    assert out is not svc._inference_providers
+    woollama = [p for p in out if p.name == "woollama"]
+    assert woollama and woollama[0]._model == "ollama/other" and woollama[0]._temperature == 0.5
+    # deterministic tiers still present and untouched
+    assert {"templates", "rules"} <= {p.name for p in out}
+
+
+def test_profile_model_feeds_the_override(svc, tmp_path):
+    # End-to-end of the Phase 1 → Phase 2 seam: a profile's resolved model is exactly
+    # what generate()/delegate() would pass as the per-call override.
+    rp = resolve_profile(Profile(tools="none", model="ollama/from-profile", temperature=0.4), svc.toolbox)
+    assert rp.model == "ollama/from-profile" and rp.temperature == 0.4
+    overridden = svc._providers_for(rp.model, rp.temperature)
+    llm = [p for p in overridden if p.name == "woollama"][0]
+    assert llm._model == "ollama/from-profile" and llm._temperature == 0.4


### PR DESCRIPTION
**Phase 2 of kits→profiles** ([design #26](https://github.com/teaguesterling/lackpy/pull/26) §8). **Stacked on [#27](https://github.com/teaguesterling/lackpy/pull/27)** (base = `feat/profiles-phase1`; review #27 first, this diff is Phase 2 only). Wires the *mechanism* a profile uses to pick a per-task model — the public `profile=` param is Phase 3.

### What lands
- **`WoollamaProvider.with_overrides(model=, temperature=)`** — clone the LLM tier with those two overridden, every other knob (retry-temp / api_key / base_url / options / params) preserved.
- **`generate()` / `delegate()` gain `model`/`temperature` overrides.** A new **`_providers_for(model, temperature)`** returns the **global list unchanged when neither is set** (invariant 8 — identical behavior, zero allocation), else a per-call copy with the LLM tier cloned (deterministic templates/rules pass through). Both the spm and legacy dispatcher paths use it.
- **Deletes the `getattr(provider, "_model")` reflection** (the surprise flagged in the design mining): the configured model is recorded as `self._llm_model` at init; PolicyContext's model is `model or self._llm_model` — same value, no longer fragile.

### Why it's safe
The only change to *existing* behavior is the reflection → explicit-field swap, which yields the same model for every config (with-woollama: the configured model; without: `None`). Everything else is gated behind a non-`None` override. **Full suite: 661 passed, 12 skipped.**

These are exactly the values Phase 1's `resolve_profile` produces — Phase 3 just threads profile-derived `model`/`mode` into `generate()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)