### PR TITLE
feat(mcp): stable lackpy-mcp launch command for external consumers

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -331,9 +331,21 @@ Start the lackpy MCP server over stdio transport.
 lackpyctl mcp serve
 ```
 
+!!! tip "Dedicated launch command for external consumers"
+    An MCP client that spawns lackpy as a backend (e.g. a `mcp.json`/`.mcp.json`
+    `command`) should use the stable, dedicated entry point — equivalent to
+    `lackpyctl mcp serve`, but a single command with no subcommand:
+
+    ```bash
+    lackpy-mcp [--workspace DIR]     # canonical, decoupled
+    lackpy mcp [--workspace DIR]     # convenience alias on the runner CLI
+    ```
+
+    This is the form `lackpyctl mcp init` writes into `.mcp.json`.
+
 ### `lackpyctl mcp init`
 
-Add lackpy to `.mcp.json`.
+Add lackpy to `.mcp.json` (as a `lackpy-mcp` server entry).
 
 ```bash
 lackpyctl mcp init [--name NAME] [--force]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ lackpy-lang = { path = "packages/lackpy-lang", editable = true }
 [project.scripts]
 lackpy = "lackpy.cli:main"
 lackpyctl = "lackpy.ctl:main"
+lackpy-mcp = "lackpy.mcp.cli:mcp_main"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/lackpy"]

--- a/src/lackpy/cli.py
+++ b/src/lackpy/cli.py
@@ -122,6 +122,12 @@ def main(argv: list[str] | None = None) -> int:
     # Pre-parse: detect bare file argument before argparse sees it.
     # If the first non-flag token ends with .py (and isn't a flag), treat it as a file.
     raw_args = argv if argv is not None else sys.argv[1:]
+    # `lackpy mcp [--workspace …]` → start the MCP server on stdio. Matches an external
+    # consumer's `command: "lackpy", args: ["mcp"]` (e.g. woollama's mcp.json); the
+    # dedicated `lackpy-mcp` console script is the canonical, decoupled form.
+    if raw_args and raw_args[0] == "mcp":
+        from .mcp.cli import mcp_main
+        return mcp_main(raw_args[1:])
     first_positional = next(
         (a for a in raw_args if not a.startswith("-")), None
     )

--- a/src/lackpy/mcp/cli.py
+++ b/src/lackpy/mcp/cli.py
@@ -42,8 +42,8 @@ def mcp_init(
 
     existed = name in servers
     servers[name] = {
-        "command": "lackpyctl",
-        "args": ["mcp", "serve", "--workspace", str(workspace.resolve())],
+        "command": "lackpy-mcp",
+        "args": ["--workspace", str(workspace.resolve())],
     }
 
     mcp_file.write_text(json.dumps(data, indent=2) + "\n")
@@ -58,3 +58,21 @@ def mcp_serve(workspace: Path) -> int:
     set_workspace(workspace)
     mcp.run(transport="stdio")
     return 0
+
+
+def mcp_main(argv: list[str] | None = None) -> int:
+    """Console-script entry: ``lackpy-mcp [--workspace DIR]`` — serve on stdio.
+
+    A stable, dedicated launch surface for external consumers (e.g. a woollama
+    ``mcp.json`` backend that spawns lackpy): one command, no subcommand. Equivalent
+    to ``lackpyctl mcp serve``. Also reachable as ``lackpy mcp`` for convenience.
+    """
+    import argparse
+
+    p = argparse.ArgumentParser(
+        prog="lackpy-mcp",
+        description="Start the lackpy MCP server on stdio transport.")
+    p.add_argument("--workspace", type=Path, default=None,
+                   help="Workspace directory (default: cwd)")
+    args = p.parse_args(argv)
+    return mcp_serve(args.workspace or Path.cwd())

--- a/tests/test_mcp_cli.py
+++ b/tests/test_mcp_cli.py
@@ -15,7 +15,7 @@ class TestMcpInit:
         assert mcp_file.exists()
         data = json.loads(mcp_file.read_text())
         assert "lackpy" in data["mcpServers"]
-        assert data["mcpServers"]["lackpy"]["command"] == "lackpyctl"
+        assert data["mcpServers"]["lackpy"]["command"] == "lackpy-mcp"
 
     def test_includes_workspace_in_args(self, tmp_path):
         mcp_init(workspace=tmp_path)
@@ -59,7 +59,7 @@ class TestMcpInit:
         result = mcp_init(workspace=tmp_path, force=True)
         assert result == 0
         data = json.loads(mcp_file.read_text())
-        assert data["mcpServers"]["lackpy"]["command"] == "lackpyctl"
+        assert data["mcpServers"]["lackpy"]["command"] == "lackpy-mcp"
 
     def test_custom_name(self, tmp_path):
         mcp_init(workspace=tmp_path, name="my-lackpy")
@@ -78,3 +78,37 @@ class TestMcpInit:
         mcp_file.write_text("[]")
         result = mcp_init(workspace=tmp_path)
         assert result == 1
+
+
+class TestMcpEntryPoints:
+    """The external-consumer launch surface (woollama spawns lackpy's MCP server)."""
+
+    def test_lackpy_mcp_routes_to_server(self):
+        # `lackpy mcp --help` must reach mcp_main (exit 0), not the runner's parser
+        # (which would reject 'mcp' as unrecognized → exit 2).
+        import pytest
+        from lackpy.cli import main
+        with pytest.raises(SystemExit) as e:
+            main(["mcp", "--help"])
+        assert e.value.code == 0
+
+    def test_mcp_main_parses_workspace(self, monkeypatch):
+        from lackpy.mcp import cli as mcpcli
+        seen = {}
+
+        def fake_serve(ws):
+            seen["ws"] = ws
+            return 0
+
+        monkeypatch.setattr(mcpcli, "mcp_serve", fake_serve)
+        rc = mcpcli.mcp_main(["--workspace", "/tmp/ws"])
+        assert rc == 0 and str(seen["ws"]) == "/tmp/ws"
+
+    def test_generated_config_uses_dedicated_entrypoint(self, tmp_path):
+        from lackpy.mcp.cli import mcp_init
+        mcp_init(tmp_path)
+        import json
+        data = json.loads((tmp_path / ".mcp.json").read_text())
+        entry = data["mcpServers"]["lackpy"]
+        assert entry["command"] == "lackpy-mcp"        # decoupled, spawnable as-is
+        assert "serve" not in entry["args"]            # no subcommand needed


### PR DESCRIPTION
Unblocks the **woollama-B** integration on lackpy's side. While reviewing woollama's updates, I found their planned `mcp.json` spawns lackpy as a downstream MCP backend with `command: "lackpy", args: ["mcp"]` — but that **errored**: the `lackpy` runner has no `mcp` subcommand, and the server only launched via `lackpyctl mcp serve`. So their "use lackpy as-is" plan didn't quite hold.

This adds a clean, decoupled launch surface:
- **`lackpy-mcp [--workspace DIR]`** — new console script (`lackpy.mcp.cli:mcp_main`), the canonical dedicated entry point (serves on stdio; equivalent to `lackpyctl mcp serve`).
- **`lackpy mcp [--workspace DIR]`** — the `lackpy` CLI now routes `mcp …` to the server too, matching woollama's existing `args: ["mcp"]` sketch.
- **`lackpyctl mcp init`** now generates `command: "lackpy-mcp"` (no subcommand).

Now woollama can spawn lackpy's (§11-hardened) MCP server with either `lackpy-mcp` or `lackpy mcp`. Tests lock all three paths. **677 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)