### PR TITLE
feat(literate): static effect classifier with config-driven grades

### DIFF
--- a/src/lackpy/interpreters/literate/effects.py
+++ b/src/lackpy/interpreters/literate/effects.py
@@ -1,0 +1,231 @@
+"""Static effect classification for literate cells.
+
+Maps a *compiled* cell (the Python source the kernel will ``exec``) to an
+:class:`CellEffects` profile -- *without running it*. The profile says, in terms
+of lackpy's existing :class:`~lackpy.lang.grader.Grade` lattice
+(``w``: 0=pure, 1=pinhole read, 2=scoped exec, 3=scoped write):
+
+  - what grade the cell needs (so the step can refuse cells over a profile's
+    effect ceiling *before* a single effect happens),
+  - which file paths it writes/reads with a *statically known literal* (so the
+    step can journal exactly those files and roll them back on failure), and
+  - whether it reaches for effect surface this pass can't bound (``import``,
+    ``open``, raw exec) or a dynamic path it can't journal -- i.e. the parts that
+    must be *sandboxed* rather than *transacted*.
+
+This is the foundation the effect-aware step consumes four ways: the ceiling
+gate, the file journal, the sandbox decision, and the dry-run manifest shown to
+the model/policy before commit.
+
+**Scope -- read this.** This is a *cooperative planner*, NOT a security boundary.
+Because literate cells run un-restricted Python (the prompt permits ``import os``
+etc.), no name-based AST pass can soundly enumerate every effect path. The
+classifier classifies the *declared* surface (the literate tools) precisely and
+flags a curated set of raw escape hatches as ``unanalyzable``; a determined cell
+can still alias around it. Soundness against adversarial code comes from the
+restricted-AST whitelist (the ``python`` interpreter's validator) and/or nsjail --
+not from this module. ``unanalyzable`` is exactly the "I can't bound this; the
+step must sandbox it and must not promise rollback" signal.
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+
+from ...lang.grader import Grade
+
+# name -> (grade, path-parameter-name, positional-index). The literate tools
+# (interpreters/literate/tools.py) are plain functions, so their grades live
+# here for now rather than on a ToolSpec; unifying the two is a follow-up.
+_READ_TOOLS: dict[str, tuple[Grade, str, int]] = {
+    "read_file": (Grade(1, 1), "path", 0),
+    "search_content": (Grade(1, 1), "path", 1),
+}
+_WRITE_TOOLS: dict[str, tuple[Grade, str, int]] = {
+    "write_file": (Grade(3, 3), "path", 0),
+    "apply_diff": (Grade(3, 3), "path", 0),
+}
+# Exec tools are off the "scoped" lattice -- a shell command can write anywhere,
+# spawn, or reach the network -- so they get high coupling and force a sandbox.
+_EXEC_TOOLS: dict[str, Grade] = {
+    "run_command": Grade(3, 3),
+    "run_tests": Grade(2, 3),
+}
+
+# Raw effect primitives that defeat name-based classification. Calling any of
+# these (or importing anything) means we can no longer bound the cell's effects.
+_ESCAPE_HATCH_CALLS: frozenset[str] = frozenset(
+    {"open", "eval", "exec", "compile", "__import__", "globals", "locals",
+     "getattr", "setattr", "delattr", "vars", "input"}
+)
+
+_PURE = Grade(0, 0)
+_CONSERVATIVE = Grade(3, 3)
+
+
+@dataclass(frozen=True)
+class CellEffects:
+    """A literate cell's statically-determined effect profile.
+
+    Attributes:
+        grade: Aggregate world-coupling/effects grade (max over the cell's
+            recognized effectful calls; forced to ``Grade(3, 3)`` when
+            ``unanalyzable``).
+        writes: File paths the cell writes via a *literal* argument -- the exact
+            set the step can journal for rollback.
+        reads: File paths the cell reads via a literal argument (informational;
+            reads need no rollback).
+        exec_calls: Names of exec-graded tools the cell invokes (``run_command``,
+            ``run_tests``). Non-empty => a sandbox is required.
+        dynamic_paths: A write/read tool was called with a non-literal path, so
+            its target can't be journaled statically.
+        unanalyzable: The cell reaches raw effect surface (``import`` / ``open`` /
+            raw exec) this pass can't bound. The step must sandbox it and must
+            not promise transactional rollback.
+    """
+
+    grade: Grade
+    writes: frozenset[str]
+    reads: frozenset[str]
+    exec_calls: frozenset[str]
+    dynamic_paths: bool
+    unanalyzable: bool
+
+    @property
+    def needs_sandbox(self) -> bool:
+        """Whether running this cell safely requires a sandbox boundary."""
+        return self.unanalyzable or bool(self.exec_calls)
+
+    @property
+    def transactional(self) -> bool:
+        """Whether the cell's filesystem effects can be journaled and rolled back.
+
+        True when every effect is either a pure/read op (nothing to undo) or a
+        write to a statically-known path. Exec, dynamic paths, or raw effect
+        surface make the cell non-transactional -- its effects can't be cleanly
+        reversed at the ``@continue`` commit boundary.
+        """
+        return not (self.unanalyzable or self.dynamic_paths or self.exec_calls)
+
+
+def classify_effects(compiled_source: str) -> CellEffects:
+    """Classify the effects of one compiled cell without executing it.
+
+    Args:
+        compiled_source: The Python source the kernel will ``exec`` for this
+            cell (the output of ``compiler._COMPILERS[...]``). Annotated cells
+            (``@read``/``@write``/``@diff``) compile to literal-path tool calls,
+            so they classify through the same path as raw code cells.
+
+    Returns:
+        A :class:`CellEffects`. A cell that doesn't parse is treated as
+        ``unanalyzable`` (the kernel's own static check reports the syntax error
+        separately; here we just refuse to vouch for its effects).
+    """
+    try:
+        tree = ast.parse(compiled_source)
+    except SyntaxError:
+        return CellEffects(
+            grade=_CONSERVATIVE, writes=frozenset(), reads=frozenset(),
+            exec_calls=frozenset(), dynamic_paths=True, unanalyzable=True,
+        )
+
+    grade = _PURE
+    writes: set[str] = set()
+    reads: set[str] = set()
+    exec_calls: set[str] = set()
+    dynamic_paths = False
+    unanalyzable = False
+
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Import, ast.ImportFrom)):
+            unanalyzable = True
+            continue
+        if not isinstance(node, ast.Call) or not isinstance(node.func, ast.Name):
+            # Attribute/subscript calls (p.write_text(), os.remove()) can hide
+            # effects we can't attribute to a known tool. We don't flag every
+            # method call as unanalyzable (str.join etc. are everywhere); the
+            # curated escape-hatch set below covers the dangerous bare names.
+            continue
+
+        name = node.func.id
+        if name in _ESCAPE_HATCH_CALLS:
+            unanalyzable = True
+        elif name in _READ_TOOLS:
+            g, pname, idx = _READ_TOOLS[name]
+            grade = _max_grade(grade, g)
+            literal = _literal_path(node, pname, idx)
+            if literal is None:
+                dynamic_paths = True
+            else:
+                reads.add(literal)
+        elif name in _WRITE_TOOLS:
+            g, pname, idx = _WRITE_TOOLS[name]
+            grade = _max_grade(grade, g)
+            literal = _literal_path(node, pname, idx)
+            if literal is None:
+                dynamic_paths = True
+            else:
+                writes.add(literal)
+        elif name in _EXEC_TOOLS:
+            grade = _max_grade(grade, _EXEC_TOOLS[name])
+            exec_calls.add(name)
+
+    if unanalyzable:
+        grade = _max_grade(grade, _CONSERVATIVE)
+
+    return CellEffects(
+        grade=grade,
+        writes=frozenset(writes),
+        reads=frozenset(reads),
+        exec_calls=frozenset(exec_calls),
+        dynamic_paths=dynamic_paths,
+        unanalyzable=unanalyzable,
+    )
+
+
+def combine(effects: list[CellEffects]) -> CellEffects:
+    """Aggregate a segment's per-cell effects into one profile for the manifest.
+
+    Grade is the max; path sets union; the boolean flags OR together. Describes
+    everything that happens between two ``@continue`` commit points -- the ceiling
+    gate and the dry-run manifest both consume this."""
+    grade = _PURE
+    writes: set[str] = set()
+    reads: set[str] = set()
+    exec_calls: set[str] = set()
+    dynamic_paths = False
+    unanalyzable = False
+    for e in effects:
+        grade = _max_grade(grade, e.grade)
+        writes |= e.writes
+        reads |= e.reads
+        exec_calls |= e.exec_calls
+        dynamic_paths = dynamic_paths or e.dynamic_paths
+        unanalyzable = unanalyzable or e.unanalyzable
+    return CellEffects(
+        grade=grade, writes=frozenset(writes), reads=frozenset(reads),
+        exec_calls=frozenset(exec_calls), dynamic_paths=dynamic_paths,
+        unanalyzable=unanalyzable,
+    )
+
+
+def _max_grade(a: Grade, b: Grade) -> Grade:
+    return Grade(w=max(a.w, b.w), d=max(a.d, b.d))
+
+
+def _literal_path(node: ast.Call, pname: str, idx: int) -> str | None:
+    """Extract a string-literal path argument, or None if absent/non-literal."""
+    for kw in node.keywords:  # keyword form: f(path="x")
+        if kw.arg == pname:
+            return _const_str(kw.value)
+    if idx < len(node.args):  # positional form: f("x")
+        return _const_str(node.args[idx])
+    return None
+
+
+def _const_str(node: ast.expr) -> str | None:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None

--- a/src/lackpy/interpreters/literate/effects.py
+++ b/src/lackpy/interpreters/literate/effects.py
@@ -17,6 +17,14 @@ This is the foundation the effect-aware step consumes four ways: the ceiling
 gate, the file journal, the sandbox decision, and the dry-run manifest shown to
 the model/policy before commit.
 
+**Grades are config-driven, not hardcoded.** Each literate tool's grade + effect
+kind + path argument is declared in ``tool_effects.toml`` (a ToolSpec-shaped
+table) and loaded into :data:`LITERATE_TOOL_EFFECTS`. Callers may inject a
+different map via ``classify_effects(..., tool_effects=)`` -- the seam through
+which the resolved toolbox will supply grades once the literate tools are
+registered as real graded specs (today they bypass the toolbox as plain
+functions; unifying them is the remaining follow-up).
+
 **Scope -- read this.** This is a *cooperative planner*, NOT a security boundary.
 Because literate cells run un-restricted Python (the prompt permits ``import os``
 etc.), no name-based AST pass can soundly enumerate every effect path. The
@@ -31,27 +39,49 @@ step must sandbox it and must not promise rollback" signal.
 from __future__ import annotations
 
 import ast
+import tomllib
 from dataclasses import dataclass
+from importlib.resources import files
+from typing import Mapping
 
 from ...lang.grader import Grade
 
-# name -> (grade, path-parameter-name, positional-index). The literate tools
-# (interpreters/literate/tools.py) are plain functions, so their grades live
-# here for now rather than on a ToolSpec; unifying the two is a follow-up.
-_READ_TOOLS: dict[str, tuple[Grade, str, int]] = {
-    "read_file": (Grade(1, 1), "path", 0),
-    "search_content": (Grade(1, 1), "path", 1),
-}
-_WRITE_TOOLS: dict[str, tuple[Grade, str, int]] = {
-    "write_file": (Grade(3, 3), "path", 0),
-    "apply_diff": (Grade(3, 3), "path", 0),
-}
-# Exec tools are off the "scoped" lattice -- a shell command can write anywhere,
-# spawn, or reach the network -- so they get high coupling and force a sandbox.
-_EXEC_TOOLS: dict[str, Grade] = {
-    "run_command": Grade(3, 3),
-    "run_tests": Grade(2, 3),
-}
+
+@dataclass(frozen=True)
+class ToolEffect:
+    """Effect descriptor for one literate tool (one row of tool_effects.toml).
+
+    Attributes:
+        grade: The tool's world-coupling/effects grade.
+        kind: ``"read"`` | ``"write"`` | ``"exec"`` -- selects the enforcement
+            mechanism (read=run, write=journal, exec=sandbox).
+        path_arg: Name of the parameter carrying a file path, or None.
+        path_index: Positional index of that parameter, or None.
+    """
+
+    grade: Grade
+    kind: str
+    path_arg: str | None = None
+    path_index: int | None = None
+
+
+def _load_tool_effects() -> dict[str, ToolEffect]:
+    """Load the literate tool effect table from the shipped TOML data."""
+    raw = (files(__package__) / "tool_effects.toml").read_text(encoding="utf-8")
+    table: dict[str, ToolEffect] = {}
+    for t in tomllib.loads(raw).get("tools", []):
+        table[t["name"]] = ToolEffect(
+            grade=Grade(w=t.get("grade_w", 3), d=t.get("effects_ceiling", 3)),
+            kind=t["kind"],
+            path_arg=t.get("path_arg"),
+            path_index=t.get("path_index"),
+        )
+    return table
+
+
+# The literate tool namespace's effect grades -- the single, config-driven source
+# of truth (tool_effects.toml). Injectable per-call via classify_effects().
+LITERATE_TOOL_EFFECTS: dict[str, ToolEffect] = _load_tool_effects()
 
 # Raw effect primitives that defeat name-based classification. Calling any of
 # these (or importing anything) means we can no longer bound the cell's effects.
@@ -76,9 +106,9 @@ class CellEffects:
             set the step can journal for rollback.
         reads: File paths the cell reads via a literal argument (informational;
             reads need no rollback).
-        exec_calls: Names of exec-graded tools the cell invokes (``run_command``,
+        exec_calls: Names of exec-kind tools the cell invokes (``run_command``,
             ``run_tests``). Non-empty => a sandbox is required.
-        dynamic_paths: A write/read tool was called with a non-literal path, so
+        dynamic_paths: A path-bearing tool was called with a non-literal path, so
             its target can't be journaled statically.
         unanalyzable: The cell reaches raw effect surface (``import`` / ``open`` /
             raw exec) this pass can't bound. The step must sandbox it and must
@@ -109,7 +139,11 @@ class CellEffects:
         return not (self.unanalyzable or self.dynamic_paths or self.exec_calls)
 
 
-def classify_effects(compiled_source: str) -> CellEffects:
+def classify_effects(
+    compiled_source: str,
+    *,
+    tool_effects: Mapping[str, ToolEffect] | None = None,
+) -> CellEffects:
     """Classify the effects of one compiled cell without executing it.
 
     Args:
@@ -117,12 +151,16 @@ def classify_effects(compiled_source: str) -> CellEffects:
             cell (the output of ``compiler._COMPILERS[...]``). Annotated cells
             (``@read``/``@write``/``@diff``) compile to literal-path tool calls,
             so they classify through the same path as raw code cells.
+        tool_effects: Name -> :class:`ToolEffect` map defining which calls are
+            graded effects. Defaults to :data:`LITERATE_TOOL_EFFECTS` (loaded
+            from ``tool_effects.toml``); inject a toolbox-derived map to override.
 
     Returns:
         A :class:`CellEffects`. A cell that doesn't parse is treated as
         ``unanalyzable`` (the kernel's own static check reports the syntax error
         separately; here we just refuse to vouch for its effects).
     """
+    effects_map = tool_effects if tool_effects is not None else LITERATE_TOOL_EFFECTS
     try:
         tree = ast.parse(compiled_source)
     except SyntaxError:
@@ -152,25 +190,23 @@ def classify_effects(compiled_source: str) -> CellEffects:
         name = node.func.id
         if name in _ESCAPE_HATCH_CALLS:
             unanalyzable = True
-        elif name in _READ_TOOLS:
-            g, pname, idx = _READ_TOOLS[name]
-            grade = _max_grade(grade, g)
-            literal = _literal_path(node, pname, idx)
+            continue
+
+        te = effects_map.get(name)
+        if te is None:
+            continue
+
+        grade = _max_grade(grade, te.grade)
+        if te.kind == "exec":
+            exec_calls.add(name)
+        elif te.kind in ("read", "write"):
+            literal = _literal_path(node, te.path_arg, te.path_index)
             if literal is None:
                 dynamic_paths = True
+            elif te.kind == "write":
+                writes.add(literal)
             else:
                 reads.add(literal)
-        elif name in _WRITE_TOOLS:
-            g, pname, idx = _WRITE_TOOLS[name]
-            grade = _max_grade(grade, g)
-            literal = _literal_path(node, pname, idx)
-            if literal is None:
-                dynamic_paths = True
-            else:
-                writes.add(literal)
-        elif name in _EXEC_TOOLS:
-            grade = _max_grade(grade, _EXEC_TOOLS[name])
-            exec_calls.add(name)
 
     if unanalyzable:
         grade = _max_grade(grade, _CONSERVATIVE)
@@ -215,12 +251,13 @@ def _max_grade(a: Grade, b: Grade) -> Grade:
     return Grade(w=max(a.w, b.w), d=max(a.d, b.d))
 
 
-def _literal_path(node: ast.Call, pname: str, idx: int) -> str | None:
+def _literal_path(node: ast.Call, pname: str | None, idx: int | None) -> str | None:
     """Extract a string-literal path argument, or None if absent/non-literal."""
-    for kw in node.keywords:  # keyword form: f(path="x")
-        if kw.arg == pname:
-            return _const_str(kw.value)
-    if idx < len(node.args):  # positional form: f("x")
+    if pname is not None:
+        for kw in node.keywords:  # keyword form: f(path="x")
+            if kw.arg == pname:
+                return _const_str(kw.value)
+    if idx is not None and idx < len(node.args):  # positional form: f("x")
         return _const_str(node.args[idx])
     return None
 

--- a/src/lackpy/interpreters/literate/tool_effects.toml
+++ b/src/lackpy/interpreters/literate/tool_effects.toml
@@ -1,0 +1,63 @@
+# Effect grades for the literate tool namespace (interpreters/literate/tools.py).
+#
+# Single, config-driven source of truth consumed by effects.classify_effects --
+# NOT hardcoded in Python. Each entry is shaped as a ToolSpec subset (grade_w /
+# effects_ceiling) plus the two things the effect classifier needs beyond a
+# grade: the effect `kind` and which argument carries a path. This shape lets the
+# table fold into the toolbox's graded-source stack (default_tools.toml /
+# ConfigToolSource) when the literate tools are registered as real specs.
+#
+# kind:
+#   read  -> pinhole read; nothing to roll back (transactional)
+#   write -> scoped write; journalable when its path arg is a literal
+#   exec  -> subprocess/shell; sandbox boundary, never transactional
+# path_arg / path_index: the parameter (name + positional index) holding the
+#   file path, used to extract a literal target for the rollback journal.
+
+[[tools]]
+name = "read_file"
+grade_w = 1
+effects_ceiling = 1
+kind = "read"
+path_arg = "path"
+path_index = 0
+
+[[tools]]
+name = "search_content"
+grade_w = 1
+effects_ceiling = 1
+kind = "read"
+path_arg = "path"
+path_index = 1
+
+[[tools]]
+name = "write_file"
+grade_w = 3
+effects_ceiling = 3
+kind = "write"
+path_arg = "path"
+path_index = 0
+
+[[tools]]
+name = "apply_diff"
+grade_w = 3
+effects_ceiling = 3
+kind = "write"
+path_arg = "path"
+path_index = 0
+
+[[tools]]
+# Scoped exec (pytest within the tree). Exec, so sandboxed + non-transactional.
+name = "run_tests"
+grade_w = 2
+effects_ceiling = 3
+kind = "exec"
+
+[[tools]]
+# Unscoped shell -- off the "scoped" lattice (can write anywhere / network).
+# Graded at the write ceiling (w=3) so the ceiling gate sees its blast radius,
+# but kind=exec so it is sandboxed and never journaled/rolled back.
+name = "run_command"
+grade_w = 3
+effects_ceiling = 3
+kind = "exec"

--- a/tests/literate/test_effects.py
+++ b/tests/literate/test_effects.py
@@ -6,10 +6,13 @@ every case here is pure input -> CellEffects with no kernel, no filesystem.
 
 from lackpy.interpreters.literate.effects import (
     CellEffects,
+    ToolEffect,
+    LITERATE_TOOL_EFFECTS,
     classify_effects,
     combine,
 )
 from lackpy.interpreters.literate.compiler import compile_document
+from lackpy.lang.grader import Grade
 
 
 def test_pure_compute_is_grade_zero_and_transactional():
@@ -154,3 +157,37 @@ def test_celleffects_is_frozen():
     assert isinstance(eff, CellEffects)
     import dataclasses
     assert dataclasses.is_dataclass(eff)
+
+
+# --- config-driven grade table (the "(b)" mechanism: grades from data, injectable) ---
+
+def test_grades_load_from_toml_covering_the_literate_tools():
+    assert set(LITERATE_TOOL_EFFECTS) == {
+        "read_file", "search_content", "write_file",
+        "apply_diff", "run_tests", "run_command",
+    }
+    assert LITERATE_TOOL_EFFECTS["write_file"].grade.w == 3
+    assert LITERATE_TOOL_EFFECTS["read_file"].kind == "read"
+    # run_command: write-ceiling blast radius but exec mechanism (sandbox).
+    rc = LITERATE_TOOL_EFFECTS["run_command"]
+    assert rc.grade.w == 3 and rc.kind == "exec" and rc.path_arg is None
+
+
+def test_injected_tool_effects_override_the_default_table():
+    # A caller (e.g. a session sourcing grades from the resolved toolbox) can
+    # supply its own map; the built-in names are then NOT classified.
+    custom = {"my_writer": ToolEffect(Grade(3, 3), "write", "path", 0)}
+    eff = classify_effects("my_writer('out.x', 'data')", tool_effects=custom)
+    assert eff.writes == frozenset({"out.x"})
+    assert eff.grade.w == 3
+    # read_file is absent from the injected map -> treated as a plain call.
+    eff2 = classify_effects("read_file('x')", tool_effects=custom)
+    assert eff2.reads == frozenset()
+    assert eff2.grade.w == 0
+
+
+def test_unknown_tool_name_is_ignored():
+    eff = classify_effects("frobnicate('x')")
+    assert eff.grade.w == 0
+    assert not eff.needs_sandbox
+    assert eff.transactional

--- a/tests/literate/test_effects.py
+++ b/tests/literate/test_effects.py
@@ -1,0 +1,156 @@
+"""Tests for static effect classification of literate cells.
+
+classify_effects() operates on *compiled* cell source and never executes it, so
+every case here is pure input -> CellEffects with no kernel, no filesystem.
+"""
+
+from lackpy.interpreters.literate.effects import (
+    CellEffects,
+    classify_effects,
+    combine,
+)
+from lackpy.interpreters.literate.compiler import compile_document
+
+
+def test_pure_compute_is_grade_zero_and_transactional():
+    eff = classify_effects("x = 1 + 2\ny = x * 10")
+    assert eff.grade.w == 0
+    assert eff.writes == frozenset() and eff.reads == frozenset()
+    assert not eff.unanalyzable and not eff.dynamic_paths
+    assert not eff.needs_sandbox
+    assert eff.transactional  # nothing to roll back
+
+
+def test_literal_read_is_pinhole_and_transactional():
+    eff = classify_effects("print(read_file('README.md'))")
+    assert eff.grade.w == 1
+    assert eff.reads == frozenset({"README.md"})
+    assert eff.writes == frozenset()
+    assert eff.transactional  # reads need no rollback
+    assert not eff.needs_sandbox
+
+
+def test_literal_write_is_scoped_write_and_journalable():
+    eff = classify_effects("write_file('src/utils.py', 'x = 1')")
+    assert eff.grade.w == 3
+    assert eff.writes == frozenset({"src/utils.py"})
+    assert eff.transactional  # literal path -> journalable
+    assert not eff.needs_sandbox
+
+
+def test_apply_diff_is_a_write_target():
+    eff = classify_effects("apply_diff('a.py', '--- a\\n+++ b\\n')")
+    assert eff.grade.w == 3
+    assert eff.writes == frozenset({"a.py"})
+    assert eff.transactional
+
+
+def test_write_kwarg_path_is_recognized():
+    eff = classify_effects("write_file(path='k.py', content='x')")
+    assert eff.writes == frozenset({"k.py"})
+
+
+def test_dynamic_write_path_is_not_transactional():
+    eff = classify_effects("p = 'out.py'\nwrite_file(p, 'x')")
+    assert eff.grade.w == 3
+    assert eff.writes == frozenset()  # path not statically known
+    assert eff.dynamic_paths
+    assert not eff.transactional  # can't journal an unknown target
+
+
+def test_search_content_path_is_second_arg():
+    eff = classify_effects("search_content('TODO', 'src')")
+    assert eff.grade.w == 1
+    assert eff.reads == frozenset({"src"})
+    assert eff.transactional
+
+
+def test_run_command_needs_sandbox_and_is_not_transactional():
+    eff = classify_effects("run_command('ls -la')")
+    assert eff.grade.w == 3
+    assert eff.exec_calls == frozenset({"run_command"})
+    assert eff.needs_sandbox
+    assert not eff.transactional  # exec can't be rolled back
+
+
+def test_run_tests_is_exec():
+    eff = classify_effects("run_tests('tests')")
+    assert "run_tests" in eff.exec_calls
+    assert eff.needs_sandbox
+    assert not eff.transactional
+
+
+def test_import_makes_cell_unanalyzable_and_conservative():
+    eff = classify_effects("import os\nos.remove('x')")
+    assert eff.unanalyzable
+    assert eff.grade.w == 3  # forced conservative
+    assert eff.needs_sandbox
+    assert not eff.transactional
+
+
+def test_open_is_an_escape_hatch():
+    eff = classify_effects("open('x', 'w').write('y')")
+    assert eff.unanalyzable
+    assert not eff.transactional
+
+
+def test_syntax_error_is_unanalyzable_not_a_crash():
+    eff = classify_effects("write_file('x',")  # truncated
+    assert eff.unanalyzable
+    assert not eff.transactional
+
+
+def test_method_calls_are_not_blanket_unanalyzable():
+    # str.join / list.append etc. must NOT trip the escape-hatch flag, or every
+    # ordinary code cell would be marked unanalyzable.
+    eff = classify_effects("parts = []\nparts.append('a')\nout = ', '.join(parts)")
+    assert not eff.unanalyzable
+    assert eff.grade.w == 0
+    assert eff.transactional
+
+
+def test_combine_takes_max_grade_and_unions_paths():
+    a = classify_effects("print(read_file('a.txt'))")
+    b = classify_effects("write_file('b.py', 'x')")
+    agg = combine([a, b])
+    assert agg.grade.w == 3  # max(read=1, write=3)
+    assert agg.reads == frozenset({"a.txt"})
+    assert agg.writes == frozenset({"b.py"})
+    assert agg.transactional  # both halves are transactional
+
+
+def test_combine_is_poisoned_by_one_exec_cell():
+    safe = classify_effects("write_file('b.py', 'x')")
+    risky = classify_effects("run_command('rm -rf /tmp/x')")
+    agg = combine([safe, risky])
+    assert agg.needs_sandbox
+    assert not agg.transactional  # one non-transactional cell taints the segment
+
+
+def test_empty_combine_is_pure():
+    agg = combine([])
+    assert agg.grade.w == 0
+    assert agg.transactional
+    assert not agg.needs_sandbox
+
+
+def test_classifies_through_the_real_compiler():
+    # The annotated forms compile to literal-path tool calls, so they classify
+    # identically to hand-written tool calls -- the uniform-path claim.
+    doc = (
+        "```lackpy @write(src/out.py)\n"
+        "value = 1\n"
+        "```\n"
+    )
+    compiled = compile_document(doc)
+    eff = classify_effects(compiled)
+    assert "src/out.py" in eff.writes
+    assert eff.grade.w == 3
+    assert eff.transactional
+
+
+def test_celleffects_is_frozen():
+    eff = classify_effects("x = 1")
+    assert isinstance(eff, CellEffects)
+    import dataclasses
+    assert dataclasses.is_dataclass(eff)


### PR DESCRIPTION
## What

A static, execution-free **effect classifier** for literate cells — the *sensor* the upcoming effect-aware step builds on. Two commits:

1. **`abe5630`** — `classify_effects(compiled_source) → CellEffects`: a pure AST pass mapping a compiled literate cell to its effect profile against the existing `Grade(w,d)` lattice — grade, statically-known write/read paths, exec calls, `dynamic_paths`/`unanalyzable` flags, plus derived `.needs_sandbox` / `.transactional`. Annotated cells (`@read`/`@write`/`@diff`) compile to literal-path tool calls, so one walk classifies annotated and raw cells uniformly.
2. **`e51c3d4`** — grades move out of hardcoded dicts into config-driven `tool_effects.toml` (a ToolSpec-shaped table: `grade_w`/`effects_ceiling` + effect `kind` + path arg), loaded into `LITERATE_TOOL_EFFECTS`. `classify_effects(..., tool_effects=)` adds an injection seam so a session can later supply grades from the resolved toolbox.

## Why

Side effects — especially filesystem writes — need to be first-class in the literate step (ceiling gate, `@continue` rollback journal, sandbox decision, dry-run manifest). All of those need to know *what a cell will do before running it*. This is that knowledge, reusing the grade lattice lackpy already has rather than inventing a new effect model. The `kind` field keeps grade (blast radius, for the ceiling) orthogonal to enforcement (e.g. `run_command` is `w=3` but `kind=exec` → sandbox, never journaled).

## Scope / non-goals

- **Cooperative planner, not a security boundary.** Literate runs unrestricted Python, so a name-based pass can't soundly enumerate every effect; raw escape hatches (`import`/`open`/…) are flagged `unanalyzable` → "must sandbox, no rollback." Real containment still rests on the restricted whitelist + nsjail.
- No stdlib grading and no new sqlite registry (deliberately deferred; the conservative `unanalyzable → sandbox` default is safe).
- Literate tools' `ToolSpec` registration (closing the plain-function side-door) and the actuator (the effect-aware step itself) are follow-ups.

## Tests

`tests/literate/test_effects.py` — 21 cases, all pure input→output, zero execution (grades, path extraction, dynamic/exec/unanalyzable, TOML load, injection override, the negative `.join`/`.append`-aren't-unanalyzable case). Full suite: **930 passed, 12 skipped**, no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkQezApY9azCwb61ELo86e