### PR TITLE
feat(literate): effect ceiling gate

### DIFF
--- a/src/lackpy/interpreters/literate/__init__.py
+++ b/src/lackpy/interpreters/literate/__init__.py
@@ -22,6 +22,8 @@ from ..base import (
     InterpreterExecutionResult,
     InterpreterValidationResult,
 )
+from .compiler import compile_cells
+from .effects import classify_effects, exceeds_ceiling
 from .kernel import LightweightKernel
 from .parser import parse
 from .prompt import LITERATE_HINT
@@ -77,6 +79,28 @@ class LiterateInterpreter:
                 output_format="none",
                 duration_ms=(time.perf_counter() - start) * 1000,
             )
+
+        # Effect ceiling gate (effects-core-to-the-step). When the context carries
+        # a `grade_ceiling` Grade, refuse a document whose aggregate effects exceed
+        # it -- statically, before any cell runs. No ceiling => no gate (behaviour
+        # unchanged). This is the first consumer of the effect classifier; the
+        # @continue file journal and sandbox fail-closed are later slices.
+        ceiling = context.config.get("grade_ceiling")
+        if ceiling is not None:
+            doc_effects = classify_effects(compile_cells(parsed))
+            violation = exceeds_ceiling(doc_effects, ceiling)
+            if violation:
+                return InterpreterExecutionResult(
+                    success=False,
+                    error=f"effect ceiling exceeded: {violation}",
+                    output_format="none",
+                    duration_ms=(time.perf_counter() - start) * 1000,
+                    metadata={
+                        "effects": doc_effects,
+                        "ceiling": ceiling,
+                        "needs_sandbox": doc_effects.needs_sandbox,
+                    },
+                )
 
         namespace = _build_namespace(context)
         kernel = LightweightKernel(namespace=namespace)

--- a/src/lackpy/interpreters/literate/__init__.py
+++ b/src/lackpy/interpreters/literate/__init__.py
@@ -14,16 +14,25 @@ recovery, plugin orchestration, and parse-as-you-generate execution.
 
 from __future__ import annotations
 
+import ast
 import time
 from typing import Any
 
+from ...lang.grader import Grade
 from ..base import (
     ExecutionContext,
     InterpreterExecutionResult,
     InterpreterValidationResult,
 )
-from .compiler import compile_cells
-from .effects import classify_effects, exceeds_ceiling
+from .compiler import compile_cell
+from .effects import (
+    LITERATE_TOOL_EFFECTS,
+    ToolEffect,
+    as_grade,
+    classify_effects,
+    combine,
+    exceeds_ceiling,
+)
 from .kernel import LightweightKernel
 from .parser import parse
 from .prompt import LITERATE_HINT
@@ -81,13 +90,30 @@ class LiterateInterpreter:
             )
 
         # Effect ceiling gate (effects-core-to-the-step). When the context carries
-        # a `grade_ceiling` Grade, refuse a document whose aggregate effects exceed
-        # it -- statically, before any cell runs. No ceiling => no gate (behaviour
-        # unchanged). This is the first consumer of the effect classifier; the
-        # @continue file journal and sandbox fail-closed are later slices.
-        ceiling = context.config.get("grade_ceiling")
-        if ceiling is not None:
-            doc_effects = classify_effects(compile_cells(parsed))
+        # a `grade_ceiling`, refuse a document whose aggregate effects exceed it --
+        # statically, before any cell runs. No ceiling => no gate (behaviour
+        # unchanged). First consumer of the effect classifier; the @continue file
+        # journal and sandbox fail-closed are later slices.
+        #
+        # NOTE: this gates only the batch path. The StreamingDriver path is not yet
+        # gated -- a follow-up slice must mirror this there. Cells are also compiled
+        # here and again by the kernel (cheap for small docs; a later slice can
+        # compile once and feed both).
+        raw_ceiling = (context.config or {}).get("grade_ceiling")
+        if raw_ceiling is not None:
+            ceiling = as_grade(raw_ceiling)
+            effects_map = _gate_effects_map(context)
+            cell_effects = []
+            for cell in parsed.cells:
+                src = compile_cell(cell)
+                try:
+                    ast.parse(src)
+                except SyntaxError:
+                    # Skip a malformed cell so the kernel reports the precise
+                    # syntax error rather than a misleading ceiling refusal.
+                    continue
+                cell_effects.append(classify_effects(src, tool_effects=effects_map))
+            doc_effects = combine(cell_effects)
             violation = exceeds_ceiling(doc_effects, ceiling)
             if violation:
                 return InterpreterExecutionResult(
@@ -164,6 +190,34 @@ _INTERNAL_NAMES = frozenset({
     "__literate_continue__", "__builtins__",
     "__continue_requested__",
 })
+
+
+def _gate_effects_map(context: ExecutionContext) -> dict[str, ToolEffect]:
+    """Effect grades the ceiling gate scores against, for THIS context.
+
+    Starts from the literate builtins (``LITERATE_TOOL_EFFECTS``) and adds any
+    profile/toolbox-injected tools (``context.tools``) graded by their own
+    ``ToolSpec``. Without this the gate would only know the builtins, so an
+    injected write-capable tool would classify as pure and slip under a
+    read-only ceiling -- the gate's validation surface must match the execution
+    surface (``_build_namespace`` injects the same ``context.tools`` callables).
+
+    Injected tools carry no literate-specific path metadata, so ``kind`` is
+    derived from the grade (w>=3 write, w==2 exec, else read); only the grade
+    matters for the ceiling comparison. Conservative defaults (3/3) for tools
+    missing a grade fail closed -- safer to over-refuse than under-refuse.
+    """
+    effects_map = dict(LITERATE_TOOL_EFFECTS)
+    resolved = context.tools
+    specs = getattr(resolved, "tools", None) if resolved is not None else None
+    for name, spec in (specs or {}).items():
+        if name in effects_map:
+            continue
+        w = getattr(spec, "grade_w", 3)
+        d = getattr(spec, "effects_ceiling", 3)
+        kind = "write" if w >= 3 else "exec" if w == 2 else "read"
+        effects_map[name] = ToolEffect(grade=Grade(w, d), kind=kind)
+    return effects_map
 
 
 def _build_namespace(context: ExecutionContext) -> dict[str, Any]:

--- a/src/lackpy/interpreters/literate/compiler.py
+++ b/src/lackpy/interpreters/literate/compiler.py
@@ -190,6 +190,18 @@ _COMPILERS: dict[str, Callable[[Cell], str]] = {
 }
 
 
+def compile_cell(cell: Cell) -> str:
+    """Compile a single cell to Python source.
+
+    Raises ``ValueError`` on an unknown cell type (the parser only emits known
+    types, so this is a guard, not an expected path). Used by the effect-ceiling
+    gate to classify cells one at a time."""
+    compiler = _COMPILERS.get(cell.cell_type)
+    if compiler is None:
+        raise ValueError(f"Unknown cell type: {cell.cell_type}")
+    return compiler(cell)
+
+
 def compile_cells(parse_result: ParseResult) -> str:
     """Compile a parsed document into a single Python program."""
     parts: list[str] = []

--- a/src/lackpy/interpreters/literate/effects.py
+++ b/src/lackpy/interpreters/literate/effects.py
@@ -247,6 +247,21 @@ def combine(effects: list[CellEffects]) -> CellEffects:
     )
 
 
+def exceeds_ceiling(effects: CellEffects, ceiling: Grade) -> str | None:
+    """Return a human-readable reason if ``effects`` exceeds ``ceiling``, else None.
+
+    The gate compares both grade axes -- world-coupling (``w``) and effects-depth
+    (``d``). The literate step calls this on a segment's combined effects to refuse
+    a document whose aggregate effects exceed the profile's allowed grade *before*
+    any cell runs. ``w`` is reported first because it is the coupling axis that
+    decides enforcement (read/exec/write)."""
+    if effects.grade.w > ceiling.w:
+        return f"world-coupling w={effects.grade.w} exceeds ceiling w={ceiling.w}"
+    if effects.grade.d > ceiling.d:
+        return f"effects-depth d={effects.grade.d} exceeds ceiling d={ceiling.d}"
+    return None
+
+
 def _max_grade(a: Grade, b: Grade) -> Grade:
     return Grade(w=max(a.w, b.w), d=max(a.d, b.d))
 

--- a/src/lackpy/interpreters/literate/effects.py
+++ b/src/lackpy/interpreters/literate/effects.py
@@ -83,11 +83,16 @@ def _load_tool_effects() -> dict[str, ToolEffect]:
 # of truth (tool_effects.toml). Injectable per-call via classify_effects().
 LITERATE_TOOL_EFFECTS: dict[str, ToolEffect] = _load_tool_effects()
 
-# Raw effect primitives that defeat name-based classification. Calling any of
-# these (or importing anything) means we can no longer bound the cell's effects.
+# Raw effect primitives that defeat name-based classification: code execution
+# (eval/exec/compile/__import__), dynamic attribute access (getattr/setattr/
+# delattr), file/stdin I/O (open/input). Calling any (or importing anything)
+# means we can no longer bound the cell's effects. NOTE: locals/globals/vars are
+# deliberately NOT here -- they are pure namespace introspection (no world
+# effect), and the first-party @scratch directive compiles to locals(); flagging
+# them would falsely refuse benign read-only documents under a low ceiling.
 _ESCAPE_HATCH_CALLS: frozenset[str] = frozenset(
-    {"open", "eval", "exec", "compile", "__import__", "globals", "locals",
-     "getattr", "setattr", "delattr", "vars", "input"}
+    {"open", "eval", "exec", "compile", "__import__",
+     "getattr", "setattr", "delattr", "input"}
 )
 
 _PURE = Grade(0, 0)
@@ -260,6 +265,25 @@ def exceeds_ceiling(effects: CellEffects, ceiling: Grade) -> str | None:
     if effects.grade.d > ceiling.d:
         return f"effects-depth d={effects.grade.d} exceeds ceiling d={ceiling.d}"
     return None
+
+
+def as_grade(value: object) -> Grade:
+    """Coerce a ceiling spec into a :class:`Grade`.
+
+    Accepts a ``Grade`` (returned as-is), a ``(w, d)`` pair, or a single int
+    (applied to both axes). This lets a config/TOML-sourced ``grade_ceiling``
+    (often a list or int) be used without the caller hand-building a ``Grade``."""
+    if isinstance(value, Grade):
+        return value
+    if isinstance(value, bool):  # bool is an int subclass; reject the ambiguity
+        raise TypeError(f"grade_ceiling must not be a bool; got {value!r}")
+    if isinstance(value, int):
+        return Grade(value, value)
+    if isinstance(value, (tuple, list)) and len(value) == 2:
+        return Grade(int(value[0]), int(value[1]))
+    raise TypeError(
+        f"grade_ceiling must be a Grade, (w, d) pair, or int; got {value!r}"
+    )
 
 
 def _max_grade(a: Grade, b: Grade) -> Grade:

--- a/tests/literate/test_effects.py
+++ b/tests/literate/test_effects.py
@@ -4,10 +4,13 @@ classify_effects() operates on *compiled* cell source and never executes it, so
 every case here is pure input -> CellEffects with no kernel, no filesystem.
 """
 
+import pytest
+
 from lackpy.interpreters.literate.effects import (
     CellEffects,
     ToolEffect,
     LITERATE_TOOL_EFFECTS,
+    as_grade,
     classify_effects,
     combine,
     exceeds_ceiling,
@@ -224,3 +227,43 @@ def test_unanalyzable_doc_is_caught_by_a_low_ceiling():
     # import -> unanalyzable -> conservative w=3, so a read-only ceiling refuses it.
     eff = classify_effects("import os\nos.remove('x')")
     assert exceeds_ceiling(eff, Grade(1, 1)) is not None
+
+
+# --- review fixes: introspection not a hatch, as_grade coercion ---
+
+def test_introspection_is_not_an_escape_hatch():
+    # locals/globals/vars are pure namespace introspection (no world effect) and
+    # the first-party @scratch directive compiles to locals() -- flagging them
+    # would falsely refuse benign read-only docs (review finding #2/#8).
+    for src in ("locals()", "globals()", "vars()"):
+        eff = classify_effects(src)
+        assert not eff.unanalyzable, src
+        assert eff.grade.w == 0, src
+
+
+def test_scratch_directive_classifies_as_pure():
+    from lackpy.interpreters.literate.compiler import compile_document
+    compiled = compile_document("```lackpy @scratch\na = 10\nb = 'x'\n```")
+    eff = classify_effects(compiled)
+    assert not eff.unanalyzable
+    assert eff.grade.w == 0  # benign introspection, allowed under any ceiling
+
+
+def test_open_still_an_escape_hatch_after_introspection_removed():
+    # Removing locals/globals/vars must not weaken the genuine hatches.
+    assert classify_effects("open('x','w')").unanalyzable
+    assert classify_effects("eval('1+1')").unanalyzable
+
+
+def test_as_grade_coerces_grade_int_and_pair():
+    assert as_grade(Grade(2, 3)) == Grade(2, 3)
+    assert as_grade(2) == Grade(2, 2)
+    assert as_grade((1, 3)) == Grade(1, 3)
+    assert as_grade([0, 0]) == Grade(0, 0)
+
+
+def test_as_grade_rejects_garbage_and_bool():
+    with pytest.raises(TypeError):
+        as_grade("high")
+    with pytest.raises(TypeError):
+        as_grade(True)  # bool is an int subclass; reject the ambiguity

--- a/tests/literate/test_effects.py
+++ b/tests/literate/test_effects.py
@@ -10,6 +10,7 @@ from lackpy.interpreters.literate.effects import (
     LITERATE_TOOL_EFFECTS,
     classify_effects,
     combine,
+    exceeds_ceiling,
 )
 from lackpy.interpreters.literate.compiler import compile_document
 from lackpy.lang.grader import Grade
@@ -191,3 +192,35 @@ def test_unknown_tool_name_is_ignored():
     assert eff.grade.w == 0
     assert not eff.needs_sandbox
     assert eff.transactional
+
+
+# --- the ceiling gate (slice 1: refuse before running if effects exceed grade) ---
+
+def test_exceeds_ceiling_on_world_coupling():
+    write = classify_effects("write_file('a.py', 'x')")  # w=3
+    assert exceeds_ceiling(write, Grade(1, 3)) is not None  # w=3 > ceiling w=1
+    assert "w=3" in exceeds_ceiling(write, Grade(1, 3))
+
+
+def test_within_ceiling_passes():
+    read = classify_effects("print(read_file('a.py'))")  # w=1
+    assert exceeds_ceiling(read, Grade(1, 1)) is None  # exactly at ceiling -> ok
+    assert exceeds_ceiling(read, Grade(3, 3)) is None
+
+
+def test_pure_doc_passes_a_zero_ceiling():
+    pure = classify_effects("x = 1 + 2")
+    assert exceeds_ceiling(pure, Grade(0, 0)) is None
+
+
+def test_exceeds_ceiling_on_effects_depth():
+    # d over, w within: still a violation, reported on the d axis.
+    eff = CellEffects(Grade(1, 3), frozenset(), frozenset(), frozenset(), False, False)
+    msg = exceeds_ceiling(eff, Grade(2, 2))
+    assert msg is not None and "d=3" in msg
+
+
+def test_unanalyzable_doc_is_caught_by_a_low_ceiling():
+    # import -> unanalyzable -> conservative w=3, so a read-only ceiling refuses it.
+    eff = classify_effects("import os\nos.remove('x')")
+    assert exceeds_ceiling(eff, Grade(1, 1)) is not None

--- a/tests/literate/test_interpreter.py
+++ b/tests/literate/test_interpreter.py
@@ -1,13 +1,12 @@
 """Integration tests for the LiterateInterpreter."""
 
-import os
-from pathlib import Path
-
 import pytest
 
 from lackpy.interpreters.base import ExecutionContext
 from lackpy.interpreters.literate import LiterateInterpreter
 from lackpy.lang.grader import Grade
+from lackpy.tools.registry import ResolvedTools
+from lackpy.tools.toolbox import ToolSpec
 
 
 @pytest.fixture
@@ -310,3 +309,64 @@ class TestCeilingGate:
         result = await interpreter.execute(doc, ctx)
         assert result.success
         assert (tmp_path / "out.py").exists()
+
+    @pytest.mark.asyncio
+    async def test_scratch_directive_allowed_under_read_ceiling(self, interpreter, workspace):
+        # Review #2/#8: @scratch compiles to locals(); it must NOT be refused as
+        # an escape hatch under a read-only ceiling.
+        ctx = ExecutionContext(base_dir=workspace, config={"grade_ceiling": Grade(1, 1)})
+        doc = "```lackpy @read(hello.txt)\n```\n\n```lackpy @scratch\nx = 1\n```"
+        result = await interpreter.execute(doc, ctx)
+        assert result.success
+
+    @pytest.mark.asyncio
+    async def test_injected_tool_is_graded_by_the_gate(self, interpreter, tmp_path):
+        # Review #1/#3: a profile-injected write-capable tool must be graded by
+        # the gate, not slip under a read-only ceiling as a pure call.
+        called = []
+        spec = ToolSpec(name="custom_writer", provider="python", description="w",
+                        args=[], returns="bool", grade_w=3, effects_ceiling=3)
+        resolved = ResolvedTools(
+            tools={"custom_writer": spec},
+            callables={"custom_writer": lambda p, d: called.append(p)},
+            grade=Grade(3, 3), description="custom",
+        )
+        doc = '```lackpy\ncustom_writer("out.txt", "data")\n```'
+
+        ctx = ExecutionContext(base_dir=tmp_path, tools=resolved,
+                               config={"grade_ceiling": Grade(1, 1)})
+        result = await interpreter.execute(doc, ctx)
+        assert not result.success                 # refused
+        assert "w=3" in result.error
+        assert called == []                       # tool never ran
+
+        ctx2 = ExecutionContext(base_dir=tmp_path, tools=resolved,
+                                config={"grade_ceiling": Grade(3, 3)})
+        result2 = await interpreter.execute(doc, ctx2)
+        assert result2.success and called          # allowed + ran under a write ceiling
+
+    @pytest.mark.asyncio
+    async def test_syntax_error_reports_kernel_error_not_ceiling(self, interpreter, tmp_path):
+        # Review #9: a cell with a Python typo under a low ceiling must surface the
+        # real syntax error, not a misleading "effect ceiling exceeded".
+        ctx = ExecutionContext(base_dir=tmp_path, config={"grade_ceiling": Grade(1, 1)})
+        result = await interpreter.execute("```lackpy\nx = (1 +\n```", ctx)
+        assert not result.success
+        assert "ceiling" not in (result.error or "")
+        assert "syntax" in (result.error or "").lower()
+
+    @pytest.mark.asyncio
+    async def test_ceiling_accepts_a_pair_or_int(self, interpreter, tmp_path):
+        # Review #6: a config/TOML-sourced ceiling (list/int) is coerced.
+        for ceiling in ([1, 1], 1):
+            ctx = ExecutionContext(base_dir=tmp_path, config={"grade_ceiling": ceiling})
+            result = await interpreter.execute("```lackpy @write(o.py)\nv=1\n```", ctx)
+            assert not result.success
+            assert "ceiling" in result.error
+
+    @pytest.mark.asyncio
+    async def test_none_config_does_not_crash(self, interpreter, tmp_path):
+        # Review #4: tolerate config=None (against the dict default-factory contract).
+        ctx = ExecutionContext(base_dir=tmp_path, config=None)
+        result = await interpreter.execute("Hello", ctx)
+        assert result.success

--- a/tests/literate/test_interpreter.py
+++ b/tests/literate/test_interpreter.py
@@ -7,6 +7,7 @@ import pytest
 
 from lackpy.interpreters.base import ExecutionContext
 from lackpy.interpreters.literate import LiterateInterpreter
+from lackpy.lang.grader import Grade
 
 
 @pytest.fixture
@@ -275,3 +276,37 @@ The first line is: {first_line}"""
         assert result.success
         assert "2 lines" in result.output
         assert "def main():" in result.output
+
+
+class TestCeilingGate:
+    """The effect ceiling gate: refuse a document whose aggregate effects exceed
+    the context's grade_ceiling -- statically, before any cell runs."""
+
+    @pytest.mark.asyncio
+    async def test_gate_refuses_doc_over_ceiling(self, interpreter, tmp_path):
+        # A write-grade (w=3) doc under a read-only ceiling (w=1) is refused
+        # before running -- the target file must NOT be created.
+        ctx = ExecutionContext(base_dir=tmp_path, config={"grade_ceiling": Grade(1, 1)})
+        doc = "```lackpy @write(out.py)\nvalue = 1\n```\n"
+        result = await interpreter.execute(doc, ctx)
+        assert not result.success
+        assert "effect ceiling exceeded" in result.error
+        assert "w=3" in result.error
+        assert not (tmp_path / "out.py").exists()  # gate ran before the write
+
+    @pytest.mark.asyncio
+    async def test_gate_allows_doc_within_ceiling(self, interpreter, tmp_path):
+        ctx = ExecutionContext(base_dir=tmp_path, config={"grade_ceiling": Grade(1, 1)})
+        doc = "```lackpy @hidden\nx = 2 + 2\n```\n\nResult: {x}"
+        result = await interpreter.execute(doc, ctx)
+        assert result.success
+        assert "Result: 4" in result.output
+
+    @pytest.mark.asyncio
+    async def test_no_ceiling_means_no_gate(self, interpreter, tmp_path):
+        # Without a grade_ceiling the doc runs as before (writes the file).
+        ctx = ExecutionContext(base_dir=tmp_path)
+        doc = "```lackpy @write(out.py)\nvalue = 1\n```\n"
+        result = await interpreter.execute(doc, ctx)
+        assert result.success
+        assert (tmp_path / "out.py").exists()


### PR DESCRIPTION
## What

Wires the effect classifier (#34) into `LiterateInterpreter.execute` as its **first consumer** — **slice 1 of the effect-aware step**. When the execution context carries a `grade_ceiling` (a `Grade`), the interpreter classifies the document's aggregate effects and **refuses before running** if they exceed the ceiling on either axis (world-coupling `w` / effects-depth `d`).

- New: `effects.exceeds_ceiling(effects, ceiling) -> str | None` — pure, two-axis comparison.
- `execute()` runs the gate *after* parse, *before* building the namespace/kernel — so a refused write never touches the filesystem (a test asserts the target file is not created).
- **No ceiling → no gate.** The default `ExecutionContext` has no `grade_ceiling`, so existing behavior is unchanged (all prior literate tests pass untouched).

## Why

#34 added the classifier but nothing consumed it. This makes it *enforce*: a profile can now cap what a literate document is allowed to do, statically, with no execution risk. It's the smallest additive slice that turns the sensor into policy — the heavier machinery (the `@continue` file journal + transactional rollback, sandbox fail-closed, dry-run manifest) builds on this.

## Tests (+8, suite 930 → 938)

- `test_effects.py`: `exceeds_ceiling` units — over-`w`, over-`d`, within/at-ceiling, pure-vs-zero-ceiling, and unanalyzable-caught-by-low-ceiling.
- `test_interpreter.py` `TestCeilingGate`: refuses an over-grade doc and **leaves the filesystem untouched**; allows a within-ceiling doc; and no-ceiling means no gate (writes as before).

## Follow-ups (not in this PR)

- Wire a profile's policy ceiling into `context.config["grade_ceiling"]` so the gate is enforced in production (it's opt-in via config today).
- Register the literate tools as graded `ToolSpec`s (close the plain-function side-door; feed the classifier via the `tool_effects=` seam).
- The transactional `@continue` journal, sandbox fail-closed, and dry-run manifest slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkQezApY9azCwb61ELo86e