### PR TITLE
feat(literate): default effect ceiling to the granted toolset grade

### DIFF
--- a/src/lackpy/interpreters/literate/__init__.py
+++ b/src/lackpy/interpreters/literate/__init__.py
@@ -89,17 +89,26 @@ class LiterateInterpreter:
                 duration_ms=(time.perf_counter() - start) * 1000,
             )
 
-        # Effect ceiling gate (effects-core-to-the-step). When the context carries
-        # a `grade_ceiling`, refuse a document whose aggregate effects exceed it --
-        # statically, before any cell runs. No ceiling => no gate (behaviour
-        # unchanged). First consumer of the effect classifier; the @continue file
-        # journal and sandbox fail-closed are later slices.
+        # Effect ceiling gate (effects-core-to-the-step). Refuse a document whose
+        # aggregate effects exceed the ceiling -- statically, before any cell runs.
+        # First consumer of the effect classifier; the @continue file journal and
+        # sandbox fail-closed are later slices.
+        #
+        # Profile -> ceiling wiring: an explicit context.config["grade_ceiling"]
+        # wins; otherwise the ceiling DEFAULTS to the granted toolset's grade
+        # (ResolvedProfile.grade == its tools' grade), i.e. a document may not
+        # exceed the effect grade of the tools its profile granted. No ceiling and
+        # no toolset => no gate (behaviour unchanged). (End-to-end enforcement in
+        # the agent path additionally needs execution-axis dispatch to run literate
+        # under a profile -- a separate slice.)
         #
         # NOTE: this gates only the batch path. The StreamingDriver path is not yet
         # gated -- a follow-up slice must mirror this there. Cells are also compiled
         # here and again by the kernel (cheap for small docs; a later slice can
         # compile once and feed both).
         raw_ceiling = (context.config or {}).get("grade_ceiling")
+        if raw_ceiling is None:
+            raw_ceiling = getattr(context.tools, "grade", None)
         if raw_ceiling is not None:
             ceiling = as_grade(raw_ceiling)
             effects_map = _gate_effects_map(context)

--- a/tests/literate/test_interpreter.py
+++ b/tests/literate/test_interpreter.py
@@ -370,3 +370,33 @@ class TestCeilingGate:
         ctx = ExecutionContext(base_dir=tmp_path, config=None)
         result = await interpreter.execute("Hello", ctx)
         assert result.success
+
+    @staticmethod
+    def _toolset(grade_w):
+        spec = ToolSpec(name="reader", provider="python", description="r",
+                        args=[], returns="str", grade_w=grade_w, effects_ceiling=grade_w)
+        return ResolvedTools(tools={"reader": spec}, callables={"reader": lambda: "x"},
+                             grade=Grade(grade_w, grade_w), description="t")
+
+    @pytest.mark.asyncio
+    async def test_ceiling_defaults_to_granted_toolset_grade(self, interpreter, tmp_path):
+        # Profile -> ceiling wiring: with NO explicit ceiling, the gate caps the
+        # document at the granted toolset's grade. A read-only toolset (w=1)
+        # refuses a write-builtin doc; a write-capable toolset (w=3) allows it.
+        write_doc = "```lackpy @write(o.py)\nv = 1\n```"
+
+        ro = ExecutionContext(base_dir=tmp_path, tools=self._toolset(1))
+        result = await interpreter.execute(write_doc, ro)
+        assert not result.success and "w=3" in result.error
+        assert not (tmp_path / "o.py").exists()
+
+        rw = ExecutionContext(base_dir=tmp_path, tools=self._toolset(3))
+        assert (await interpreter.execute(write_doc, rw)).success
+
+    @pytest.mark.asyncio
+    async def test_explicit_ceiling_overrides_toolset_grade(self, interpreter, tmp_path):
+        # An explicit config ceiling wins over the toolset-grade default.
+        ctx = ExecutionContext(base_dir=tmp_path, tools=self._toolset(3),
+                               config={"grade_ceiling": Grade(1, 1)})
+        result = await interpreter.execute("```lackpy @write(o.py)\nv=1\n```", ctx)
+        assert not result.success


### PR DESCRIPTION
## What
Profile → ceiling wiring for the effect-ceiling gate (#35). When no explicit `context.config["grade_ceiling"]` is set, the gate now **defaults the ceiling to `context.tools.grade`** (`ResolvedProfile.grade` *is* its tools' grade). So **a document may not exceed the effect grade of the tools its profile granted** — a read-only toolset refuses a write-builtin doc automatically, without the caller passing a ceiling by hand.

- Explicit `config` ceiling still wins.
- No toolset **and** no ceiling → no gate (unchanged).

## Why
#35 left the gate opt-in (nothing set a ceiling). This makes it enforce wherever literate runs with a resolved toolset, keyed on the principled rule "you can't exceed your granted tools' grade" — self-contained in the interpreter, no dependency on dispatch infrastructure.

## Honest scope
End-to-end enforcement in the *agent* path additionally needs **execution-axis dispatch** — the `execution` axis is carried on `ResolvedProfile` but not yet consumed to select the literate interpreter (today literate runs via the standalone `scripts/literate_agent.py`, not a profile dispatcher). That dispatch is a separate slice; this PR lands the wiring so the gate activates the moment a profile's tools reach the interpreter.

## Tests (+2, suite 948 → 950)
Read-only toolset refuses a write doc (file not created) / write-capable toolset allows it / explicit ceiling overrides the toolset-grade default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkQezApY9azCwb61ELo86e