### PR TITLE
feat(literate): always-on transactional write journal

### DIFF
--- a/src/lackpy/interpreters/literate/__init__.py
+++ b/src/lackpy/interpreters/literate/__init__.py
@@ -33,6 +33,7 @@ from .effects import (
     combine,
     exceeds_ceiling,
 )
+from .journal import FileJournal
 from .kernel import LightweightKernel
 from .parser import parse
 from .prompt import LITERATE_HINT
@@ -89,40 +90,39 @@ class LiterateInterpreter:
                 duration_ms=(time.perf_counter() - start) * 1000,
             )
 
-        # Effect ceiling gate (effects-core-to-the-step). Refuse a document whose
-        # aggregate effects exceed the ceiling -- statically, before any cell runs.
-        # First consumer of the effect classifier; the @continue file journal and
-        # sandbox fail-closed are later slices.
+        # Effects-core-to-the-step: classify the document once (statically, before
+        # any cell runs), then drive two mechanisms off the result -- an always-on
+        # write journal and a conditional ceiling gate.
         #
-        # Profile -> ceiling wiring: an explicit context.config["grade_ceiling"]
-        # wins; otherwise the ceiling DEFAULTS to the granted toolset's grade
-        # (ResolvedProfile.grade == its tools' grade), i.e. a document may not
-        # exceed the effect grade of the tools its profile granted. No ceiling and
-        # no toolset => no gate (behaviour unchanged). (End-to-end enforcement in
-        # the agent path additionally needs execution-axis dispatch to run literate
-        # under a profile -- a separate slice.)
-        #
-        # NOTE: this gates only the batch path. The StreamingDriver path is not yet
-        # gated -- a follow-up slice must mirror this there. Cells are also compiled
-        # here and again by the kernel (cheap for small docs; a later slice can
-        # compile once and feed both).
+        # Cells that don't parse are skipped here so the kernel reports the precise
+        # syntax error rather than a misleading refusal. (Cells are compiled here
+        # and again by the kernel -- cheap for small docs; a later slice can compile
+        # once and feed both. This gates/journals only the batch path; the
+        # StreamingDriver path is a follow-up slice.)
+        effects_map = _gate_effects_map(context)
+        cell_effects = []
+        for cell in parsed.cells:
+            src = compile_cell(cell)
+            try:
+                ast.parse(src)
+            except SyntaxError:
+                continue
+            cell_effects.append(classify_effects(src, tool_effects=effects_map))
+        doc_effects = combine(cell_effects)
+
+        # Ceiling gate (conditional): refuse a document whose aggregate effects
+        # exceed the ceiling, before any cell runs. Profile -> ceiling wiring: an
+        # explicit context.config["grade_ceiling"] wins; otherwise the ceiling
+        # DEFAULTS to the granted toolset's grade (ResolvedProfile.grade == its
+        # tools' grade) -- a document may not exceed the effect grade of the tools
+        # its profile granted. No ceiling and no toolset => no gate. (End-to-end
+        # enforcement in the agent path additionally needs execution-axis dispatch
+        # to run literate under a profile -- a separate slice.)
         raw_ceiling = (context.config or {}).get("grade_ceiling")
         if raw_ceiling is None:
             raw_ceiling = getattr(context.tools, "grade", None)
         if raw_ceiling is not None:
             ceiling = as_grade(raw_ceiling)
-            effects_map = _gate_effects_map(context)
-            cell_effects = []
-            for cell in parsed.cells:
-                src = compile_cell(cell)
-                try:
-                    ast.parse(src)
-                except SyntaxError:
-                    # Skip a malformed cell so the kernel reports the precise
-                    # syntax error rather than a misleading ceiling refusal.
-                    continue
-                cell_effects.append(classify_effects(src, tool_effects=effects_map))
-            doc_effects = combine(cell_effects)
             violation = exceeds_ceiling(doc_effects, ceiling)
             if violation:
                 return InterpreterExecutionResult(
@@ -137,6 +137,16 @@ class LiterateInterpreter:
                     },
                 )
 
+        # Write journal (always-on): snapshot the document's statically known
+        # literal writes (doc_effects.writes) so the whole batch run is atomic for
+        # those files -- any cell failure rolls them back, so a failed document
+        # leaves the filesystem as it was. Dynamic-path/exec/unanalyzable effects
+        # are out of the journal's reach (see journal.py); when a ceiling is set it
+        # is what keeps those out of a policy-governed run. Transaction boundary is
+        # the whole execute() call; per-@continue commit points are a later slice.
+        journal = FileJournal(context.base_dir)
+        journal.snapshot(doc_effects.writes)
+
         namespace = _build_namespace(context)
         kernel = LightweightKernel(namespace=namespace)
 
@@ -148,6 +158,9 @@ class LiterateInterpreter:
             result = kernel.execute_cell(cell, index)
 
             if not result.success:
+                # Roll the document's known writes back to their pre-run state so a
+                # failed document does not leave half-applied files behind.
+                journal.rollback()
                 return InterpreterExecutionResult(
                     success=False,
                     error=result.error or "Unknown error",
@@ -162,6 +175,9 @@ class LiterateInterpreter:
 
             if result.namespace_delta.get("__continue_requested__"):
                 continue_requested = True
+
+        # Every cell ran: accept the writes (drop the snapshots).
+        journal.commit()
 
         elapsed = (time.perf_counter() - start) * 1000
 

--- a/src/lackpy/interpreters/literate/journal.py
+++ b/src/lackpy/interpreters/literate/journal.py
@@ -1,0 +1,73 @@
+"""Transactional file journal for the literate batch path.
+
+Snapshots a set of files before a document's write-cells run, so the whole
+document's *statically known, literal-path* writes can be rolled back atomically
+if any cell fails. Only paths the effect classifier surfaced as ``writes``
+(literal-arg ``@write``/``@diff``/``write_file``/``apply_diff`` targets) are
+journaled; dynamic-path writes, exec (``run_command``), and unanalyzable cells
+are NOT covered -- their effects can't be bounded statically. Pair with the
+ceiling gate (which refuses exec/unanalyzable cells under a low ceiling) to get
+full atomicity for a policy-governed run.
+
+The transaction boundary here is the whole batch ``execute()`` call. Per-cell
+``@continue`` commit points are a streaming/fold concern for a later slice.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Iterable
+
+from .tools import _resolve as _resolve_tool_path
+
+
+class FileJournal:
+    """Records pre-execution file contents so writes can be undone on failure.
+
+    For each tracked path the journal stores either its bytes (file existed) or
+    ``None`` (file did not exist). ``rollback`` restores those bytes or deletes a
+    file that was created during the transaction; ``commit`` drops the snapshots.
+
+    The journal resolves paths through the SAME function and base the literate
+    write tools use (``tools._resolve``), so a snapshot path is, by construction,
+    the exact path ``write_file``/``apply_diff`` will touch -- they cannot drift
+    into snapshotting one file while the write lands on another.
+    """
+
+    def __init__(self, base_dir: str | Path | None = None) -> None:
+        # Mirror make_tool_namespace: base is None when unset (the tools then
+        # resolve relative paths against the cwd, and so do we -- via the shared
+        # _resolve, at the same call sites within one execute()).
+        self._base = Path(base_dir) if base_dir else None
+        self._snapshots: dict[Path, bytes | None] = {}
+
+    def _resolve(self, path: str) -> Path:
+        return _resolve_tool_path(path, self._base)
+
+    def snapshot(self, paths: Iterable[str]) -> None:
+        """Record the current state of each path (idempotent per path)."""
+        for path in paths:
+            rp = self._resolve(path)
+            if rp in self._snapshots:
+                continue
+            self._snapshots[rp] = rp.read_bytes() if rp.is_file() else None
+
+    def rollback(self) -> None:
+        """Restore every tracked path to its snapshotted state."""
+        for rp, content in self._snapshots.items():
+            if content is None:
+                # The run created it -> remove it. Guard against a directory
+                # sharing the path (unlink on a dir raises): only files/symlinks.
+                if rp.is_file() or rp.is_symlink():
+                    rp.unlink()
+            else:
+                rp.parent.mkdir(parents=True, exist_ok=True)
+                rp.write_bytes(content)
+
+    def commit(self) -> None:
+        """Accept the writes -- drop the snapshots so nothing can be rolled back."""
+        self._snapshots.clear()
+
+    @property
+    def tracked(self) -> int:
+        return len(self._snapshots)

--- a/tests/literate/test_interpreter.py
+++ b/tests/literate/test_interpreter.py
@@ -400,3 +400,66 @@ class TestCeilingGate:
                                config={"grade_ceiling": Grade(1, 1)})
         result = await interpreter.execute("```lackpy @write(o.py)\nv=1\n```", ctx)
         assert not result.success
+
+
+class TestTransactionalWrites:
+    """@continue transactional journal: a failed document rolls its writes back.
+
+    The journal is always-on: it does not depend on a ceiling. Covers only
+    statically-known literal writes; exec / dynamic / unanalyzable effects are out
+    of scope (when a ceiling is set, it is what keeps those out of a policy-
+    governed run).
+    """
+
+    OK_CEILING = {"grade_ceiling": Grade(3, 3)}  # gate present but permissive: writes allowed
+
+    @pytest.mark.asyncio
+    async def test_failure_removes_a_newly_created_file(self, interpreter, tmp_path):
+        doc = ("```lackpy @write(out.txt)\nfresh\n```\n\n"
+               "```lackpy\nraise ValueError('boom')\n```")
+        ctx = ExecutionContext(base_dir=tmp_path, config=self.OK_CEILING)
+        result = await interpreter.execute(doc, ctx)
+        assert not result.success
+        assert not (tmp_path / "out.txt").exists()   # rolled back
+
+    @pytest.mark.asyncio
+    async def test_failure_restores_overwritten_file(self, interpreter, tmp_path):
+        (tmp_path / "keep.txt").write_text("ORIGINAL")
+        doc = ("```lackpy @write(keep.txt)\nNEW\n```\n\n"
+               "```lackpy\nx = 1 / 0\n```")
+        ctx = ExecutionContext(base_dir=tmp_path, config=self.OK_CEILING)
+        result = await interpreter.execute(doc, ctx)
+        assert not result.success
+        assert (tmp_path / "keep.txt").read_text() == "ORIGINAL"   # restored
+
+    @pytest.mark.asyncio
+    async def test_success_commits_the_write(self, interpreter, tmp_path):
+        ctx = ExecutionContext(base_dir=tmp_path, config=self.OK_CEILING)
+        result = await interpreter.execute("```lackpy @write(out.txt)\nkept\n```", ctx)
+        assert result.success
+        assert (tmp_path / "out.txt").read_text() == "kept"
+
+    @pytest.mark.asyncio
+    async def test_rollback_happens_without_a_ceiling(self, interpreter, tmp_path):
+        # The journal is always-on: rollback does not depend on a ceiling or a
+        # granted toolset. A bare run's failed write is still rolled back.
+        doc = ("```lackpy @write(out.txt)\nfresh\n```\n\n"
+               "```lackpy\nraise ValueError('boom')\n```")
+        ctx = ExecutionContext(base_dir=tmp_path)  # no ceiling, no tools
+        result = await interpreter.execute(doc, ctx)
+        assert not result.success
+        assert not (tmp_path / "out.txt").exists()   # rolled back regardless
+
+    @pytest.mark.asyncio
+    async def test_failure_restores_a_diffed_file(self, interpreter, tmp_path):
+        # apply_diff mutates an existing file -- the dangerous write-kind. A later
+        # failure must restore the original content.
+        (tmp_path / "hello.txt").write_text("Hello World\n")
+        doc = ("```lackpy @diff(hello.txt)\n"
+               "--- a/hello.txt\n+++ b/hello.txt\n@@ -1 +1 @@\n"
+               "-Hello World\n+Hello Universe\n```\n\n"
+               "```lackpy\nraise RuntimeError('boom')\n```")
+        ctx = ExecutionContext(base_dir=tmp_path, config=self.OK_CEILING)
+        result = await interpreter.execute(doc, ctx)
+        assert not result.success
+        assert (tmp_path / "hello.txt").read_text() == "Hello World\n"   # restored

--- a/tests/literate/test_journal.py
+++ b/tests/literate/test_journal.py
@@ -1,0 +1,85 @@
+"""Unit tests for the FileJournal (transactional file rollback)."""
+
+
+from lackpy.interpreters.literate.journal import FileJournal
+
+
+def test_rollback_restores_overwritten_content(tmp_path):
+    f = tmp_path / "a.txt"
+    f.write_text("original")
+    j = FileJournal(tmp_path)
+    j.snapshot(["a.txt"])
+    f.write_text("mutated")          # simulate a write-cell
+    j.rollback()
+    assert f.read_text() == "original"
+
+
+def test_rollback_deletes_files_created_after_snapshot(tmp_path):
+    j = FileJournal(tmp_path)
+    j.snapshot(["new.txt"])          # did not exist at snapshot time
+    (tmp_path / "new.txt").write_text("created")
+    j.rollback()
+    assert not (tmp_path / "new.txt").exists()
+
+
+def test_commit_drops_snapshots_so_rollback_is_a_noop(tmp_path):
+    f = tmp_path / "a.txt"
+    f.write_text("v1")
+    j = FileJournal(tmp_path)
+    j.snapshot(["a.txt"])
+    f.write_text("v2")
+    j.commit()
+    assert j.tracked == 0
+    j.rollback()                     # nothing tracked -> must not resurrect v1
+    assert f.read_text() == "v2"
+
+
+def test_snapshot_is_idempotent_per_path(tmp_path):
+    f = tmp_path / "a.txt"
+    f.write_text("first")
+    j = FileJournal(tmp_path)
+    j.snapshot(["a.txt"])
+    f.write_text("second")
+    j.snapshot(["a.txt"])            # must NOT re-snapshot the mutated content
+    assert j.tracked == 1
+    j.rollback()
+    assert f.read_text() == "first"
+
+
+def test_relative_paths_resolve_against_base_dir(tmp_path):
+    sub = tmp_path / "src"
+    sub.mkdir()
+    (sub / "m.py").write_text("orig")
+    j = FileJournal(tmp_path)
+    j.snapshot(["src/m.py"])
+    (sub / "m.py").write_text("changed")
+    j.rollback()
+    assert (sub / "m.py").read_text() == "orig"
+
+
+def test_rollback_recreates_parent_dir_if_removed(tmp_path):
+    sub = tmp_path / "pkg"
+    sub.mkdir()
+    f = sub / "x.txt"
+    f.write_text("keep")
+    j = FileJournal(tmp_path)
+    j.snapshot(["pkg/x.txt"])
+    f.unlink()                       # cell deleted the file (and we drop the dir)
+    sub.rmdir()
+    j.rollback()
+    assert f.read_text() == "keep"
+
+
+def test_rollback_skips_a_directory_sharing_the_path(tmp_path):
+    # If a tracked path is a directory at snapshot (None recorded), rollback must
+    # not unlink it (IsADirectoryError) and abort the rest of the restore.
+    d = tmp_path / "adir"
+    d.mkdir()
+    other = tmp_path / "b.txt"
+    other.write_text("orig")
+    j = FileJournal(tmp_path)
+    j.snapshot(["adir", "b.txt"])
+    other.write_text("changed")
+    j.rollback()                     # must not raise on the directory entry
+    assert other.read_text() == "orig"
+    assert d.is_dir()


### PR DESCRIPTION
## What
Adds `FileJournal` and wires it into the batch `execute()` path. The document is classified **once**; an **always-on** journal then snapshots its statically-known literal writes (`doc_effects.writes`) before any cell runs, **rolls them back if any cell fails**, and commits on success. A failed document leaves the filesystem exactly as it was — no half-applied `@write`/`@diff` — whether or not a policy ceiling is set.

This realizes the design's *"transactional as part of the step"* as an **intrinsic property** of the interpreter rather than a policy add-on. The ceiling gate (#35/#36) now reuses the same single classification and stays conditional on a ceiling; only the gate is policy-gated, the journal always runs.

## Path safety (the load-bearing bit)
The journal resolves through `tools._resolve` with the **same base** the write tools use, so a snapshot path *is* the path `write_file`/`apply_diff` will touch — they can't drift into snapshotting one file while the write lands on another. `rollback` only ever deletes files the run **itself created** (`snapshot == None`); pre-existing files are restored, never unlinked, and a directory sharing a tracked path is skipped.

## Scope / limits
Only literal-path writes are journaled. Dynamic-path writes, exec (`run_command`), and unanalyzable cells are out of reach (documented in `journal.py`) — when a ceiling is set, it's what keeps those out of a policy-governed run. The transaction boundary is the whole `execute()` call; per-`@continue` commit points are a streaming/fold concern for a later slice. The StreamingDriver path is not yet journaled (follow-up).

## Behavior change
Bare runs (no ceiling/toolset) now roll back a failed document's writes — previously they persisted. This is the safe default and was an explicit design choice (always-on vs gate-coupled).

## Tests (+12, suite 950 → 962)
7 `FileJournal` unit (restore/delete/commit/idempotency/relative-resolve/dir-guard) + 5 atomic-write integration (new-file removed, existing-file restored, **`@diff` restore**, success commits, rollback-without-a-ceiling).

## Reviewer note
The advisor caught the resolver-drift risk pre-merge; the fix (share `tools._resolve` + the same base) is included, with a `@diff` rollback test and a directory guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkQezApY9azCwb61ELo86e