### PR TITLE
feat(service): dispatch run_program by the profile execution axis

### DIFF
--- a/src/lackpy/service.py
+++ b/src/lackpy/service.py
@@ -524,6 +524,74 @@ class LackpyService:
         finally:
             os.chdir(prev_cwd)
 
+    async def _execute_program(
+        self, program: str, rp: ResolvedProfile, resolved: Any,
+        param_values: dict[str, Any], *, allowed: set[str] | None = None,
+        rules: list | None = None, kibitzer_session: Any = None,
+    ) -> ExecutionResult:
+        """Route a program to the execution model named by the profile's ``execution``
+        axis -- the shared seam for ``run_program`` (and, next, ``delegate``).
+
+        Validation lives ABOVE the branch: a literate document is NOT restricted
+        Python, so it must not pass through the restricted-Python validator (which
+        would reject its fences/prose as a syntax error and never reach the gate).
+        ``execution == "literate"`` validates and runs the program through the
+        LiterateInterpreter, whose ceiling gate + write journal enforce the granted
+        toolset's grade; any other axis is restricted Python -- validated against
+        the allowed names, then run through the restricted runner (unchanged).
+        """
+        if rp.execution == "literate":
+            return await self._execute_literate(program, resolved, param_values)
+
+        if allowed is not None:
+            validation = validate(program, allowed_names=allowed, extra_rules=rules)
+            if not validation.valid:
+                return ExecutionResult(
+                    success=False,
+                    error=f"Validation failed: {'; '.join(validation.errors)}",
+                )
+        return await self._execute(
+            program, resolved.callables, param_values,
+            kibitzer_session=kibitzer_session,
+        )
+
+    async def _execute_literate(
+        self, program: str, resolved: Any, param_values: dict[str, Any],
+    ) -> ExecutionResult:
+        """Execute a literate document through the LiterateInterpreter, adapting its
+        result to an ``ExecutionResult``.
+
+        The granted toolset (``resolved``) is threaded as ``context.tools`` so the
+        ceiling defaults to its grade -- a document may not exceed the effect grade
+        of the tools its profile granted -- and its callables join the literate
+        namespace. ``base_dir`` is made absolute so the write journal / tool path
+        resolver is immune to the concurrent single-flight ``os.chdir`` on the
+        restricted-Python path.
+        """
+        from .interpreters.base import ExecutionContext
+        from .interpreters.literate import LiterateInterpreter
+
+        interp = LiterateInterpreter()
+        ctx = ExecutionContext(
+            base_dir=str(self._workspace.resolve()),
+            tools=resolved,
+            params=param_values,
+        )
+        validation = interp.validate(program, ctx)
+        if not validation.valid:
+            return ExecutionResult(
+                success=False,
+                error=f"Validation failed: {'; '.join(validation.errors)}",
+            )
+        result = await interp.execute(program, ctx)
+        return ExecutionResult(
+            success=result.success,
+            output=result.output,
+            stdout=str(result.output) if result.output else "",
+            error=result.error,
+            variables=result.metadata.get("variables", {}),
+        )
+
     async def run_program(self, program: str, profile: Profile | str | list[str] | dict | None = None,
                           params: dict[str, Any] | None = None, sandbox: Any = None,
                           rules: list | None = None,
@@ -543,13 +611,14 @@ class LackpyService:
         Returns:
             An ExecutionResult with output, trace, and success status.
         """
-        resolved = self._gate_tools(self._resolve_profile(profile, extra_tools=extra_tools).tools)
+        rp = self._resolve_profile(profile, extra_tools=extra_tools)
+        resolved = self._gate_tools(rp.tools)
         param_values, _, param_names = self._resolve_params(params, resolved)
         allowed = set(resolved.tools.keys()) | param_names
-        validation = validate(program, allowed_names=allowed, extra_rules=rules)
-        if not validation.valid:
-            return ExecutionResult(success=False, error=f"Validation failed: {'; '.join(validation.errors)}")
-        return await self._execute(program, resolved.callables, param_values)
+        # The execution axis (one-shot restricted-Python vs literate) decides both
+        # validation and execution; the seam keeps them paired (see _execute_program).
+        return await self._execute_program(
+            program, rp, resolved, param_values, allowed=allowed, rules=rules)
 
     async def delegate(self, intent: str, profile: Profile | str | list[str] | dict | None = None,
                        params: dict[str, Any] | None = None, sandbox: Any = None,

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -4,6 +4,7 @@ import pytest
 from pathlib import Path
 
 from lackpy.service import LackpyService
+from lackpy.profiles import Profile
 from lackpy.tools.toolbox import ToolSpec, ArgSpec
 
 
@@ -147,3 +148,53 @@ class TestLanguageSpec:
         spec = service.language_spec()
         assert "allowed_nodes" in spec
         assert "allowed_builtins" in spec
+
+
+class TestLiterateExecutionAxis:
+    """Profile `execution == "literate"` routes run_program through the
+    LiterateInterpreter, so the effect-ceiling gate (defaulting to the granted
+    toolset's grade) and the write journal enforce end-to-end via the service.
+    """
+
+    @pytest.mark.asyncio
+    async def test_write_doc_refused_under_a_read_only_literate_profile(self, service):
+        # read_file grants only a w=1 toolset -> ceiling w=1 -> a @write doc (w=3)
+        # is refused before any cell runs, and the file is never created.
+        doc = "```lackpy @write(out.txt)\nhello\n```"
+        profile = Profile(tools=["read_file"], execution="literate")
+        result = await service.run_program(doc, profile=profile)
+        assert not result.success
+        assert "effect ceiling exceeded" in (result.error or "")
+        assert not (service._workspace / "out.txt").exists()
+
+    @pytest.mark.asyncio
+    async def test_within_ceiling_doc_executes_and_renders(self, service):
+        # A pure doc (w=0) is within the read ceiling -> it runs and renders.
+        doc = "```lackpy\nx = 2 + 2\n```\n\nResult: {x}"
+        profile = Profile(tools=["read_file"], execution="literate")
+        result = await service.run_program(doc, profile=profile)
+        assert result.success
+        assert "Result: 4" in result.stdout
+
+    @pytest.mark.asyncio
+    async def test_write_allowed_when_toolset_grade_permits(self, service):
+        # Granting a w=3 tool (edit_file) raises the ceiling to w=3, so the @write
+        # doc is allowed and the literate write builtin creates the file. edit_file
+        # is deliberately NOT write_file, so it does not shadow that builtin.
+        service.toolbox.register_tool(ToolSpec(
+            name="edit_file", provider="builtin", description="edit a file",
+            args=[ArgSpec(name="path", type="str", description="File path")],
+            returns="str", grade_w=3, effects_ceiling=3,
+        ))
+        doc = "```lackpy @write(out.txt)\nkept\n```"
+        profile = Profile(tools=["read_file", "edit_file"], execution="literate")
+        result = await service.run_program(doc, profile=profile)
+        assert result.success, result.error
+        assert (service._workspace / "out.txt").read_text() == "kept"
+
+    @pytest.mark.asyncio
+    async def test_one_shot_axis_unaffected(self, service):
+        # The default execution axis still runs restricted Python through _execute.
+        result = await service.run_program(
+            "x = read_file('test.txt')\nlen(x)", profile=["read_file"])
+        assert result.success


### PR DESCRIPTION
## What
Wires the **literate interpreter into the service** so a profile with `execution == "literate"` actually runs through it. This is the **prerequisite the gate/journal slices (#35–#37) were dormant without** — it lights up the effect-ceiling gate and write journal **end-to-end** through the public `run_program` entry point.

`run_program` now keeps the full `ResolvedProfile` and routes through a new shared seam `_execute_program(program, rp, resolved, …)`.

## The load-bearing bit: validation routing
The seam pairs **validation with execution, per axis** — because validation sat *above* the old execution call:
- `execution == "literate"` → validate + run via `LiterateInterpreter` (parse-based validation + ceiling gate + write journal). The doc never reaches the restricted-Python validator, which would reject its fences/prose as a syntax error and the gate would never fire.
- any other axis → restricted Python, validated against the allowed names, then the existing runner (**unchanged**).

`_execute_literate` adapts the `InterpreterExecutionResult` → `ExecutionResult` and threads the granted toolset as `context.tools` (grade → ceiling default; callables → namespace), with an **absolute `base_dir`** so the journal/tool resolver is immune to the restricted path's single-flight `os.chdir`.

## Scope (narrowed deliberately)
`run_program` only. The **generation half** — prompting the model to *emit* literate docs and routing `delegate`'s kibitzer `validate_calls` — is separable and larger; `delegate`/`generate` adopt `_execute_program` next with **no rework**. The `StreamingDriver` path is still ungated (follow-up).

## Tests (+4, suite 962 → 966)
The discriminating one proves `profile.tools.grade → ceiling → gate` through the service: a **read-only** literate profile refuses a `@write` doc with *"effect ceiling exceeded"* and creates **no file**; a w=3 toolset **allows** it (file created); a pure doc renders; the **one-shot axis is unchanged**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkQezApY9azCwb61ELo86e