### PR TITLE
feat(service): literate generation + delegate dispatch (the generation half)

### DIFF
--- a/src/lackpy/service.py
+++ b/src/lackpy/service.py
@@ -58,6 +58,35 @@ def _strip_top_level_return(program: str) -> str:
     return ast.unparse(tree)
 
 
+_LITERATE_PREAMBLE_MARKERS = ("here's", "here is", "the following", "the document")
+
+
+def _strip_literate_wrapper(raw: str) -> str:
+    """Literate-safe cleanup of a model's raw output before parsing it.
+
+    A literate document IS markdown-with-fenced-code, so the standard
+    ``sanitize_output`` is unusable here: it unwraps *any* leading ``` fence and
+    would eat the first (and last) ```lackpy block of a doc that opens with code.
+    This instead strips only a leading conversational preamble line and an
+    explicit OUTER ``` ```markdown ``` / ``` ```md ``` wrapper -- never the inner
+    ``` ```lackpy ``` fences the document is made of.
+    """
+    text = raw.strip()
+    if not text:
+        return ""
+    lines = text.split("\n")
+    while lines and any(m in lines[0].lower() for m in _LITERATE_PREAMBLE_MARKERS):
+        lines = lines[1:]
+    text = "\n".join(lines).strip()
+    first = text.split("\n", 1)[0].strip().lower()
+    if first in ("```markdown", "```md") and text.rstrip().endswith("```"):
+        body = text.split("\n", 1)[1] if "\n" in text else ""
+        text = body.rstrip()
+        if text.endswith("```"):
+            text = text[:-3].rstrip()
+    return text
+
+
 try:
     from kibitzer import KibitzerSession
     _HAS_KIBITZER = True
@@ -423,6 +452,12 @@ class LackpyService:
         # model/temperature is selected. Neither selected → identical to before (invariant 8).
         providers = self._providers_for(effective_model, effective_temp)
 
+        # Literate execution needs a literate DOCUMENT, not restricted Python, so it
+        # gets its own generation path (own hint + parse validation) rather than the
+        # strategy/dispatcher paths, which frame + validate output as Python.
+        if rp.execution == "literate":
+            return await self._generate_literate(intent, providers, resolved, params_desc, rules)
+
         effective_mode = mode or rp.mode or self._config.inference_mode
 
         if effective_mode and effective_mode in STRATEGIES:
@@ -592,6 +627,47 @@ class LackpyService:
             variables=result.metadata.get("variables", {}),
         )
 
+    async def _generate_literate(
+        self, intent: str, providers: list, resolved: Any,
+        params_desc: str | None, rules: list | None,
+    ) -> "GenerationResult":
+        """Generate a literate document (the ``execution == "literate"`` path).
+
+        A literate doc is markdown, not restricted Python, so it CANNOT go through
+        the standard dispatcher: that path runs ``sanitize_output`` +
+        ``deterministic_cleanup`` + validates the result AS Python + a Python
+        correction chain -- all of which reject or mangle a fenced document. This
+        runs the provider loop with the LiterateInterpreter system-prompt hint and
+        validates each candidate by PARSING it (``LiterateInterpreter.validate``),
+        returning the first that parses. Cleanup is literate-safe (outer wrapper /
+        preamble only). No Python sanitize/correction.
+        """
+        from .infer.dispatch import GenerationResult
+        from .interpreters.base import ExecutionContext
+        from .interpreters.literate import LiterateInterpreter
+
+        interp = LiterateInterpreter()
+        vctx = ExecutionContext(base_dir=str(self._workspace.resolve()), tools=resolved)
+        namespace_desc = resolved.description
+        start = time.perf_counter()
+        errors: dict[str, list[str]] = {}
+        for provider in providers:
+            if not provider.available():
+                continue
+            raw = await provider.generate(intent, namespace_desc, interpreter=interp)
+            if not raw:
+                continue
+            program = _strip_literate_wrapper(raw)
+            validation = interp.validate(program, vctx)
+            if validation.valid:
+                elapsed = (time.perf_counter() - start) * 1000
+                return GenerationResult(
+                    program=program, provider_name=provider.name,
+                    generation_time_ms=elapsed,
+                )
+            errors[provider.name] = validation.errors
+        raise RuntimeError(f"Literate generation failed. Errors: {errors}")
+
     async def run_program(self, program: str, profile: Profile | str | list[str] | dict | None = None,
                           params: dict[str, Any] | None = None, sandbox: Any = None,
                           rules: list | None = None,
@@ -699,8 +775,12 @@ class LackpyService:
                         "correction_attempts": gen_result.correction_attempts,
                     }
 
-        exec_result = await self._execute(
-            gen_result.program, resolved.callables, param_values,
+        # Dispatch by the profile's execution axis (literate vs restricted Python),
+        # the same seam run_program uses. allowed=None preserves delegate's prior
+        # behaviour of not re-validating the generated program before _execute; the
+        # literate path validates internally by parsing.
+        exec_result = await self._execute_program(
+            gen_result.program, rp, resolved, param_values,
             kibitzer_session=self._kibitzer,
         )
 

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -1,7 +1,6 @@
 """Tests for the unified service layer."""
 
 import pytest
-from pathlib import Path
 
 from lackpy.service import LackpyService
 from lackpy.profiles import Profile
@@ -198,3 +197,72 @@ class TestLiterateExecutionAxis:
         result = await service.run_program(
             "x = read_file('test.txt')\nlen(x)", profile=["read_file"])
         assert result.success
+
+    @pytest.mark.asyncio
+    async def test_delegate_dispatches_literate_and_gate_refuses(self, service):
+        # delegate routes through the same axis seam: a write doc under a read-only
+        # literate profile is refused by the gate (via _program_override, no LLM).
+        ro = Profile(tools=["read_file"], execution="literate")
+        result = await service.delegate(
+            "x", profile=ro, _program_override="```lackpy @write(o.txt)\nhi\n```")
+        assert not result["success"]
+        assert "effect ceiling exceeded" in (result["error"] or "")
+        assert not (service._workspace / "o.txt").exists()
+
+    @pytest.mark.asyncio
+    async def test_delegate_dispatches_literate_and_renders(self, service):
+        ro = Profile(tools=["read_file"], execution="literate")
+        result = await service.delegate(
+            "x", profile=ro, _program_override="```lackpy\nx = 2 + 2\n```\n\nResult: {x}")
+        assert result["success"]
+        assert "Result: 4" in result["stdout"]
+
+
+class TestLiterateGenerationRouting:
+    """generate() routes an execution=="literate" profile to the literate
+    generation path (own hint + parse validation), not the Python dispatcher.
+    """
+
+    @pytest.mark.asyncio
+    async def test_literate_profile_uses_the_literate_generation_path(self, service, monkeypatch):
+        from lackpy.infer.dispatch import GenerationResult
+        seen = {}
+
+        async def fake_gen_literate(intent, providers, resolved, params_desc, rules):
+            seen["intent"] = intent
+            return GenerationResult(program="Hello {x}", provider_name="fake", generation_time_ms=0.0)
+
+        monkeypatch.setattr(service, "_generate_literate", fake_gen_literate)
+        result = await service.generate(
+            "greet", profile=Profile(tools=["read_file"], execution="literate"))
+        assert seen.get("intent") == "greet"
+        assert result.program == "Hello {x}"
+
+    @pytest.mark.asyncio
+    async def test_one_shot_profile_does_not_use_the_literate_path(self, service, monkeypatch):
+        async def boom(*a, **k):
+            raise AssertionError("_generate_literate must not run for a one-shot profile")
+
+        monkeypatch.setattr(service, "_generate_literate", boom)
+        result = await service.generate("read file test.txt", profile=["read_file"])
+        assert "read_file(" in result.program
+
+
+class TestStripLiterateWrapper:
+    def test_strips_leading_preamble(self):
+        from lackpy.service import _strip_literate_wrapper
+        out = _strip_literate_wrapper("Here is the document:\n```lackpy\nx=1\n```")
+        assert out == "```lackpy\nx=1\n```"
+
+    def test_strips_outer_markdown_wrapper(self):
+        from lackpy.service import _strip_literate_wrapper
+        assert _strip_literate_wrapper("```markdown\nHello {x}\n```") == "Hello {x}"
+
+    def test_preserves_inner_lackpy_fences(self):
+        from lackpy.service import _strip_literate_wrapper
+        doc = "```lackpy @write(o.txt)\nv=1\n```"
+        assert _strip_literate_wrapper(doc) == doc  # must NOT unwrap the code block
+
+    def test_empty_is_empty(self):
+        from lackpy.service import _strip_literate_wrapper
+        assert _strip_literate_wrapper("   ") == ""


### PR DESCRIPTION
## What
Completes the literate execution axis so **`delegate(intent, literate_profile)` generates *and* executes a literate document end-to-end** — the pair `run_program` dispatch (#38) left open. Ship both halves together: dispatch without generation would leave `delegate`-literate actively broken.

## Why a dedicated generation path (not "route through the dispatcher")
The advisor's blocking check came back dirty: the standard dispatcher runs `sanitize_output` → `deterministic_cleanup` → **validates the result as restricted Python** → a Python correction chain. All of that **rejects or mangles a fenced markdown document**, and `sanitize_output` unwraps any leading ``` fence — eating the first/last block of a doc that opens with code. So literate needs its own path.

`generate()`: an `execution == "literate"` profile routes to a new **`_generate_literate`** — provider loop with the `LiterateInterpreter` system-prompt hint, **literate-safe cleanup** (`_strip_literate_wrapper`: strips a preamble line + only an *outer* markdown wrapper, never the inner `lackpy` fences), and **parse-based validation** (`LiterateInterpreter.validate`). `delegate()` now dispatches through the `_execute_program` seam (#38) like `run_program`.

## Verified with a live model
`ollama qwen2.5:1.5b-cpu`:
- Prose doc → generates + renders, `success=True` (`"Hello from lackpy.\n"`).
- A doc whose model-written code raised → clean `success=False` with the error surfaced (the failure branch working).

Model **output quality** is out of scope (a 1.5b model writes imperfect code) — the *pipeline* handles it correctly; that's the wiring-vs-quality split.

## Tests (+8, suite 966 → 974)
Deterministic wiring coverage: `delegate` dispatch via `_program_override` hits the gate (write doc under a read-only literate profile → *"effect ceiling exceeded"*, no file); `generate` routes literate vs one-shot (monkeypatched); `_strip_literate_wrapper` (preamble / outer-wrapper / **inner-fence-preserved** / empty).

## Known gaps (follow-ups)
- `delegate`'s kibitzer `validate_calls` self-skips for a literate doc (the restricted-Python validator returns invalid), so mode-policy pre-checks don't yet apply to literate calls.
- The `StreamingDriver` path is still ungated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkQezApY9azCwb61ELo86e