### PR TITLE
feat(service): extend kibitzer mode policy to literate's direct tool calls

### DIFF
--- a/src/lackpy/service.py
+++ b/src/lackpy/service.py
@@ -668,6 +668,42 @@ class LackpyService:
             errors[provider.name] = validation.errors
         raise RuntimeError(f"Literate generation failed. Errors: {errors}")
 
+    def _planned_tool_calls(
+        self, program: str, rp: ResolvedProfile, allowed: set[str],
+    ) -> list[str]:
+        """Tool names a generated program will call, for the kibitzer mode-policy
+        pre-check (Python builtins excluded).
+
+        A literate document is markdown, so the restricted-Python validator rejects
+        it outright and the pre-check used to silently self-skip -- mode policy did
+        not apply to literate calls. Compile the doc to its Python form first, then
+        extract calls the same way (``validate`` collects called names during its
+        AST walk regardless of whether other rules pass, so an off-lattice doc's
+        tool calls are still surfaced). One-shot programs are unchanged: calls are
+        taken only when the program validates. Returns ``[]`` when nothing can be
+        analyzed (execution will surface the real error).
+
+        COOPERATIVE, not a security boundary -- the same limitation as the effect
+        gate. This enumerates *direct, named* calls only. An attribute call
+        (``os.system(...)``), an alias (``w = write_file; w(...)``), or reflection
+        (``getattr(...)(...)``) is NOT attributed to a tool and slips the check.
+        Soundness against adversarial docs comes from the restricted-AST whitelist
+        + nsjail, not from this pass.
+        """
+        if rp.execution == "literate":
+            try:
+                from .interpreters.literate.compiler import compile_document
+                program = compile_document(program)
+            except Exception:
+                return []
+            calls = validate(program, allowed_names=allowed).calls
+        else:
+            vr = validate(program, allowed_names=allowed)
+            if not vr.valid:
+                return []
+            calls = vr.calls
+        return [c for c in calls if c not in ALLOWED_BUILTINS]
+
     async def run_program(self, program: str, profile: Profile | str | list[str] | dict | None = None,
                           params: dict[str, Any] | None = None, sandbox: Any = None,
                           rules: list | None = None,
@@ -756,13 +792,15 @@ class LackpyService:
                                             interpreter=interpreter, extra_tools=extra_tools,
                                             model=model, temperature=temperature)
 
-        # Kibitzer: validate planned calls before execution
+        # Kibitzer: validate planned calls before execution. A literate document is
+        # compiled to its Python form first (see _planned_tool_calls) so mode policy
+        # applies to literate calls too, instead of self-skipping on the markdown.
         kibitzer_suggestions: list[str] = []
         if self._kibitzer:
-            validation_result = validate(gen_result.program, allowed_names=set(resolved.tools.keys()) | param_names)
-            if validation_result.valid:
-                planned = [{"tool": call, "input": {}} for call in validation_result.calls
-                           if call not in ALLOWED_BUILTINS]
+            planned_names = self._planned_tool_calls(
+                gen_result.program, rp, set(resolved.tools.keys()) | param_names)
+            if planned_names:  # only ever validate a non-empty call set
+                planned = [{"tool": call, "input": {}} for call in planned_names]
                 violations = self._kibitzer.validate_calls(planned)
                 if violations:
                     return {

--- a/tests/test_service.py
+++ b/tests/test_service.py
@@ -266,3 +266,96 @@ class TestStripLiterateWrapper:
     def test_empty_is_empty(self):
         from lackpy.service import _strip_literate_wrapper
         assert _strip_literate_wrapper("   ") == ""
+
+
+class _FakeKibitzer:
+    """Minimal kibitzer stand-in: records the planned calls delegate sends to
+    validate_calls, and returns a canned violation list."""
+
+    def __init__(self, violations=None):
+        self.mode = "test"
+        self.seen_planned = None
+        self._violations = violations or []
+
+    def register_context(self, *a, **k):
+        pass
+
+    def validate_calls(self, planned):
+        self.seen_planned = planned
+        return self._violations
+
+    def get_suggestions(self):
+        return []
+
+    def report_generation(self, *a, **k):
+        pass
+
+    def save(self):
+        pass
+
+
+class _Violation:
+    def __init__(self, reason):
+        self.reason = reason
+
+
+class TestLiterateModePolicy:
+    """delegate's kibitzer mode-policy pre-check now applies to literate docs
+    (previously it self-skipped because the restricted-Python validator rejects
+    the markdown outright).
+    """
+
+    def test_planned_calls_extracted_from_a_literate_doc(self, service):
+        rp = service._resolve_profile(Profile(tools=["read_file"], execution="literate"))
+        calls = service._planned_tool_calls(
+            "```lackpy\ndata = read_file('t')\n```", rp, {"read_file"})
+        assert calls == ["read_file"]
+
+    def test_annotation_calls_are_extracted_too(self, service):
+        # @write compiles to write_file(...) -- the compiled call is what policy sees.
+        rp = service._resolve_profile(Profile(tools=["read_file"], execution="literate"))
+        calls = service._planned_tool_calls("```lackpy @write(o.txt)\nhi\n```", rp, {"read_file"})
+        assert "write_file" in calls
+
+    @pytest.mark.asyncio
+    async def test_delegate_routes_literate_calls_to_mode_policy(self, service):
+        fake = _FakeKibitzer()
+        service._kibitzer = fake
+        await service.delegate(
+            "x", profile=Profile(tools=["read_file"], execution="literate"),
+            _program_override="```lackpy\ndata = read_file('t')\n```")
+        assert fake.seen_planned == [{"tool": "read_file", "input": {}}]
+
+    @pytest.mark.asyncio
+    async def test_delegate_enforces_a_literate_mode_policy_violation(self, service):
+        fake = _FakeKibitzer(violations=[_Violation("write_file blocked in test mode")])
+        service._kibitzer = fake
+        result = await service.delegate(
+            "x", profile=Profile(tools=["read_file"], execution="literate"),
+            _program_override="```lackpy @write(o.txt)\nhi\n```")
+        assert not result["success"]
+        assert "Kibitzer mode policy violation" in result["error"]
+        assert "write_file blocked" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_one_shot_calls_still_checked(self, service):
+        fake = _FakeKibitzer()
+        service._kibitzer = fake
+        await service.delegate(
+            "read file", profile=["read_file"],
+            _program_override="x = read_file('t')")
+        assert fake.seen_planned == [{"tool": "read_file", "input": {}}]
+
+    def test_cooperative_limitation_indirect_calls_bypass(self, service):
+        # Boundary pin: mode policy sees only DIRECT named calls. Attribute /
+        # aliased / reflected invocations are NOT attributed to a tool, so they
+        # slip the pre-check -- the same cooperative-planner limitation as the
+        # effect gate. Soundness is nsjail + restricted-AST, not this pass.
+        rp = service._resolve_profile(Profile(tools=["read_file"], execution="literate"))
+        allowed = {"read_file", "write_file"}
+        attribute = service._planned_tool_calls(
+            "```lackpy\nimport os\nos.system('x')\n```", rp, allowed)
+        aliased = service._planned_tool_calls(
+            "```lackpy\nw = write_file\nw('o', 'x')\n```", rp, allowed)
+        assert "write_file" not in attribute      # os.system(...) surfaces nothing
+        assert "write_file" not in aliased         # only the alias name 'w' surfaces


### PR DESCRIPTION
## What
Closes the gap flagged in #39: `delegate`'s kibitzer mode-policy pre-check **self-skipped for literate documents** — the restricted-Python validator rejects the markdown outright (`valid=False`), and the old code only checked calls when the program validated. So mode policy did not apply to literate tool calls at all.

`delegate` now extracts planned calls via a new `_planned_tool_calls(program, rp, allowed)`: a literate doc is **compiled to its Python form first** (`compile_document`), then calls are enumerated with `validate()` (whose call collection runs during the AST walk regardless of other rule failures, so an off-lattice doc's tool calls are still surfaced). One-shot is unchanged. Only a non-empty call set is sent to `validate_calls`.

## ⚠️ Cooperative, not a security boundary — the same limitation as the effect gate
This constrains **well-behaved** docs. It enumerates **direct, named** calls only. Verified bypasses:

| doc | surfaced | 
|---|---|
| `os.system(...)` (attribute) | *nothing* |
| `w = write_file; w(...)` (alias) | `'w'` (no tool match) |
| `getattr(...)(...)` (reflection) | `'getattr'` (no tool match) |
| `write_file(...)` (direct) | `write_file` ✅ |

Any doc that imports/aliases/reflects walks around it — soundness against adversarial docs is the restricted-AST whitelist + nsjail, **out of scope here**. A test **pins this boundary** so the green suite isn't read as "literate is policy-sealed."

## Tests (+6, suite 974 → 980)
Fake-kibitzer coverage: planned calls extracted (raw + `@annotation`); `delegate` routes literate calls to `validate_calls`; a literate mode-policy violation is **enforced** (`success=False`); one-shot calls still checked; **indirect-call bypass pinned**.

## Reviewer note
The advisor caught that my initial 5 tests only exercised the cooperative case on a security-framed change. This adds the adversarial verification, the boundary-pinning test, the empty-call-set guard, and qualifies the claim to match what the mechanism actually does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkQezApY9azCwb61ELo86e