### PR TITLE
feat(literate): multi-round fold session (LiterateSession)

### DIFF
--- a/scripts/literate_agent.py
+++ b/scripts/literate_agent.py
@@ -22,7 +22,7 @@ import httpx
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "src"))
 
 from lackpy.interpreters.base import ExecutionContext
-from lackpy.interpreters.literate import LiterateInterpreter
+from lackpy.interpreters.literate import LiterateInterpreter, LiterateSession
 from lackpy.prompts import DEFAULT_PERSONA, PERSONAS, compose
 
 
@@ -100,6 +100,11 @@ async def run_literate_agent(
     system_prompt = compose(persona, interpreter)
     work_dir = Path(base_dir) if base_dir else Path.cwd()
     context = ExecutionContext(base_dir=work_dir)
+    # The fold. One persistent kernel is threaded across rounds, so functions and
+    # objects defined in one round are live in the next; step() strips <think>,
+    # gates + journals the doc, and returns Either. This thin client just does the
+    # model-call loop and feeds the next round.
+    session = LiterateSession(context, interpreter=interpreter)
 
     if verbose:
         print(f"Persona: {persona}", file=sys.stderr)
@@ -120,35 +125,43 @@ async def run_literate_agent(
         response = await call_ollama(full_prompt, model=model, system=system_prompt, num_predict=num_predict, verbose=verbose)
 
         if verbose:
-            print(f"\n--- Model Response ---", file=sys.stderr)
+            print("\n--- Model Response ---", file=sys.stderr)
             print(response, file=sys.stderr)
-            print(f"--- End Response ---\n", file=sys.stderr)
+            print("--- End Response ---\n", file=sys.stderr)
 
-        result = await interpreter.execute(response, context)
+        result = await session.step(response)
 
         if verbose:
-            print(f"\n--- Execution Result ---", file=sys.stderr)
-            print(f"Success: {result.success}", file=sys.stderr)
-            if result.error:
-                print(f"Error: {result.error}", file=sys.stderr)
-            print(f"--- End Result ---\n", file=sys.stderr)
+            print("\n--- Step Result ---", file=sys.stderr)
+            print(f"ok: {result.ok}", file=sys.stderr)
+            if not result.ok:
+                print(f"Errors: {result.errors}", file=sys.stderr)
+            print("--- End Result ---\n", file=sys.stderr)
 
-        if not result.success:
-            return f"[Execution failed: {result.error}]\n\nRaw response:\n{response}"
+        if not result.ok:
+            # Left: hand the errors + the raw un-interpreted document back so the
+            # model corrects its own work. State is NOT advanced; retry this round.
+            errors = "\n".join(result.errors)
+            full_prompt = (
+                f"Your previous document failed:\n{errors}\n\n"
+                f"Here is what you wrote:\n{result.raw}\n\n"
+                f"Fix the problem and resubmit the FULL corrected document."
+            )
+            continue
 
-        if not result.metadata.get("continue_requested"):
-            return result.output
+        if not result.continue_requested:
+            return session.rendered
 
-        variables = result.metadata.get("variables", {})
-        var_summary = "\n".join(f"  {k} = {repr(v)[:200]}" for k, v in variables.items())
-
+        # Right + @continue: feed what is LIVE (session.scope), not repr text, so the
+        # model keeps building on the real objects already in the kernel.
+        scope_summary = "\n".join(f"  {k} = {v}" for k, v in session.scope.items())
         full_prompt = (
-            f"Previous execution output:\n{result.output}\n\n"
-            f"Variables available:\n{var_summary}\n\n"
+            f"Previous output:\n{result.clean_doc}\n\n"
+            f"Live variables (already in scope — do not redefine):\n{scope_summary}\n\n"
             f"Continue writing the document from where @continue left off."
         )
 
-    return result.output
+    return session.rendered
 
 
 def main():

--- a/src/lackpy/interpreters/literate/__init__.py
+++ b/src/lackpy/interpreters/literate/__init__.py
@@ -79,6 +79,24 @@ class LiterateInterpreter:
         Uses LightweightKernel directly (not StreamingDriver) because the
         batch path doesn't need streaming, recovery, or plugin orchestration.
         """
+        namespace = _build_namespace(context)
+        kernel = LightweightKernel(namespace=namespace)
+        return await self._run_document(program, context, kernel)
+
+    async def _run_document(
+        self,
+        program: str,
+        context: ExecutionContext,
+        kernel: LightweightKernel,
+    ) -> InterpreterExecutionResult:
+        """Run a literate document through an ALREADY-BUILT kernel: classify ->
+        ceiling gate -> write journal -> run cells -> render.
+
+        Shared by the batch ``execute()`` (a fresh kernel each call) and
+        ``LiterateSession.step()`` (one persistent kernel threaded across rounds).
+        The kernel owns the namespace, so this must NOT rebuild it -- doing so
+        would wipe state threaded from prior rounds.
+        """
         start = time.perf_counter()
 
         parsed = parse(program)
@@ -146,9 +164,6 @@ class LiterateInterpreter:
         # the whole execute() call; per-@continue commit points are a later slice.
         journal = FileJournal(context.base_dir)
         journal.snapshot(doc_effects.writes)
-
-        namespace = _build_namespace(context)
-        kernel = LightweightKernel(namespace=namespace)
 
         output_parts: list[str] = []
         continue_requested = False
@@ -262,3 +277,8 @@ def _build_namespace(context: ExecutionContext) -> dict[str, Any]:
         ns.update(context.params)
 
     return ns
+
+
+# Re-export the multi-round fold API. Imported at the end (after LiterateInterpreter
+# and _build_namespace are defined) so session.py's lazy imports resolve cleanly.
+from .session import LiterateSession, StepResult, strip_think  # noqa: E402,F401

--- a/src/lackpy/interpreters/literate/kernel/lightweight.py
+++ b/src/lackpy/interpreters/literate/kernel/lightweight.py
@@ -162,6 +162,20 @@ class LightweightKernel:
         import builtins
         self._namespace["__builtins__"] = builtins
 
+    def snapshot(self) -> dict[str, Any]:
+        """Shallow copy of the current namespace, for restore() after a failed
+        step. Captures name REBINDINGS only -- in-place mutations of held objects
+        are not recorded (consistent with this kernel's own delta tracking, which
+        also can't see in-place changes). A deep copy is deliberately avoided
+        (arbitrary/unpicklable live objects, cost)."""
+        return dict(self._namespace)
+
+    def restore(self, snapshot: dict[str, Any]) -> None:
+        """Restore the namespace to a prior snapshot() -- undoes name rebindings
+        made since the snapshot. In-place mutations are not reverted."""
+        self._namespace.clear()
+        self._namespace.update(snapshot)
+
     def get_namespace(self) -> dict[str, Any]:
         return {
             k: v for k, v in self._namespace.items()

--- a/src/lackpy/interpreters/literate/session.py
+++ b/src/lackpy/interpreters/literate/session.py
@@ -1,0 +1,140 @@
+"""Multi-round literate fold -- the interpreter-as-fold-returning-Either.
+
+A literate *session* folds model responses across rounds. Each round is one
+``step(raw) -> StepResult``:
+
+  - Right (success): the round's document ran cleanly. Returns the clean rendered
+    output (``<think>`` reasoning stripped) + advanced state -- the kernel is
+    mutated in place and the write journal is committed. ``@continue`` in the doc
+    surfaces as ``continue_requested`` so the caller feeds the next round.
+  - Left (failure): the round failed. Returns the errors + the *raw* un-interpreted
+    message so the model can correct its own work (cleaning would hide the bug).
+    State is NOT advanced -- file writes are rolled back (journal) and kernel name
+    rebindings are restored.
+
+The session is a PURE fold: ``step`` takes a raw string and returns a result. The
+model-call loop (prompt -> model -> step -> feed back) is a thin client's job, so
+the fold is testable without an LLM. The client feeds the next round using
+``session.scope`` (what is *live*) rather than re-injecting variables as text.
+
+The load-bearing difference from the old ``scripts/literate_agent.py`` loop: a
+SINGLE persistent kernel is threaded across rounds, so functions, imports, and
+objects defined in one round are genuinely available (as live objects) to the
+next -- the old loop rebuilt a fresh kernel each round and passed only
+``repr(v)[:200]`` text, which dropped functions entirely.
+
+Left's "state not advanced" is a rebinding-level guarantee: file writes and name
+rebindings roll back, but in-place mutations and effects beyond the journal do
+not -- cooperative, the same boundary as the effect gate.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Any
+
+from ..base import ExecutionContext
+
+# <think>...</think> reasoning blocks (a thinking model's scratch space) must not
+# reach the parser -- as prose they would print verbatim into the clean doc and
+# pollute the next round's context. Strip closed blocks, then any unclosed trailing
+# <think> (model hit the token limit mid-reasoning).
+_THINK_RE = re.compile(r"<think\b[^>]*>.*?</think>", re.DOTALL | re.IGNORECASE)
+_UNCLOSED_THINK_RE = re.compile(r"<think\b[^>]*>.*\Z", re.DOTALL | re.IGNORECASE)
+
+
+def strip_think(text: str) -> str:
+    """Remove ``<think>...</think>`` reasoning from raw model output.
+
+    Handles an unclosed ``<think>`` (truncation mid-reasoning) by stripping to the
+    end. Returns the remainder stripped of surrounding whitespace -- which may be
+    empty if the model emitted only reasoning (the session treats that as a Left).
+    """
+    text = _THINK_RE.sub("", text)
+    text = _UNCLOSED_THINK_RE.sub("", text)
+    return text.strip()
+
+
+@dataclass
+class StepResult:
+    """The Either returned by :meth:`LiterateSession.step`.
+
+    ``ok`` discriminates: Right carries ``clean_doc`` / ``continue_requested`` /
+    ``variables``; Left carries ``errors`` / ``raw`` (the un-interpreted message
+    to hand back to the model for correction).
+    """
+
+    ok: bool
+    clean_doc: str = ""
+    continue_requested: bool = False
+    variables: dict[str, Any] = field(default_factory=dict)
+    errors: list[str] = field(default_factory=list)
+    raw: str = ""
+
+
+class LiterateSession:
+    """A multi-round literate fold over a single persistent kernel.
+
+    Construct with the :class:`ExecutionContext` (tools -> ceiling + namespace,
+    ``base_dir`` -> journal). Call :meth:`step` per model response; feed the next
+    round while ``result.continue_requested`` is true, and on a Left feed
+    ``result.errors`` + ``result.raw`` back for correction.
+    """
+
+    def __init__(self, context: ExecutionContext, interpreter: Any = None) -> None:
+        # Lazy imports avoid a circular import with the package __init__ (which
+        # re-exports this module).
+        from . import LiterateInterpreter, _build_namespace
+        from .kernel import LightweightKernel
+
+        self._context = context
+        self._interpreter = interpreter or LiterateInterpreter()
+        self._kernel = LightweightKernel(namespace=_build_namespace(context))
+        self._clean_parts: list[str] = []
+
+    async def step(self, raw: str) -> StepResult:
+        """Fold one raw model response into the session. See the module docstring."""
+        doc = strip_think(raw)
+        if not doc:
+            # Only reasoning / nothing survived the strip -- a Left (retry), never
+            # a silent empty success.
+            return StepResult(
+                ok=False, raw=raw,
+                errors=["empty document after stripping <think> reasoning"],
+            )
+
+        # Snapshot BEFORE running so a failed round can undo its name rebindings.
+        snapshot = self._kernel.snapshot()
+        result = await self._interpreter._run_document(doc, self._context, self._kernel)
+
+        if not result.success:
+            # _run_document already rolled the write journal back; restore the
+            # kernel's name rebindings so state is not advanced.
+            self._kernel.restore(snapshot)
+            return StepResult(
+                ok=False, raw=raw,
+                errors=[result.error or "execution failed"],
+            )
+
+        self._clean_parts.append(result.output or "")
+        return StepResult(
+            ok=True,
+            clean_doc=result.output or "",
+            continue_requested=bool(result.metadata.get("continue_requested")),
+            variables=dict(result.metadata.get("variables", {})),
+        )
+
+    @property
+    def rendered(self) -> str:
+        """The accumulated clean document across all successful rounds."""
+        return "".join(self._clean_parts)
+
+    @property
+    def scope(self) -> dict[str, str]:
+        """What is currently *live* in the kernel (name -> type: repr summary).
+
+        The thin-client feeds this to the model between rounds instead of
+        re-injecting variables as text -- the values are already live in the kernel.
+        """
+        return self._kernel.get_scope()

--- a/tests/literate/test_session.py
+++ b/tests/literate/test_session.py
@@ -1,0 +1,123 @@
+"""Tests for the multi-round literate fold (LiterateSession)."""
+
+import pytest
+
+from lackpy.interpreters.base import ExecutionContext
+from lackpy.interpreters.literate import LiterateSession, strip_think
+from lackpy.lang.grader import Grade
+
+
+@pytest.fixture
+def context(tmp_path):
+    return ExecutionContext(base_dir=tmp_path)
+
+
+class TestLiveThreading:
+    @pytest.mark.asyncio
+    async def test_function_defined_in_round_one_is_callable_in_round_two(self, context):
+        # The DoD: the old fresh-kernel-per-round loop dropped functions entirely
+        # (filtered out of `variables`) and round 2 would fail check_cell with an
+        # undefined name. A persistent kernel threads the live function object.
+        session = LiterateSession(context)
+        r1 = await session.step(
+            "```lackpy @hidden\ndef double(n):\n    return n * 2\nbase = 10\n```")
+        assert r1.ok, r1.errors
+
+        r2 = await session.step("```lackpy\nresult = double(base) + 5\n```\n\nResult: {result}")
+        assert r2.ok, r2.errors
+        assert "Result: 25" in r2.clean_doc
+        assert r2.variables.get("result") == 25
+
+    @pytest.mark.asyncio
+    async def test_variable_threads_across_rounds(self, context):
+        session = LiterateSession(context)
+        assert (await session.step("```lackpy @hidden\nx = 7\n```")).ok
+        r2 = await session.step("```lackpy\ny = x * 3\n```\n\ny={y}")
+        assert r2.ok and "y=21" in r2.clean_doc
+
+    @pytest.mark.asyncio
+    async def test_rendered_accumulates_clean_docs(self, context):
+        session = LiterateSession(context)
+        await session.step("Round one.\n\n```lackpy @hidden\na = 1\n```")
+        await session.step("Round two.")
+        assert "Round one." in session.rendered
+        assert "Round two." in session.rendered
+
+
+class TestEitherSemantics:
+    @pytest.mark.asyncio
+    async def test_failure_returns_left_with_raw_and_errors(self, context):
+        session = LiterateSession(context)
+        raw = "```lackpy\nx = 1 / 0\n```"
+        result = await session.step(raw)
+        assert not result.ok
+        assert result.raw == raw            # the un-interpreted message, for correction
+        assert result.errors and "ZeroDivisionError" in result.errors[0]
+
+    @pytest.mark.asyncio
+    async def test_left_does_not_advance_state(self, context):
+        session = LiterateSession(context)
+        assert (await session.step("```lackpy @hidden\nx = 1\n```")).ok
+        # round 2 rebinds x then fails -> Left must restore x to 1
+        bad = await session.step("```lackpy\nx = 2\nraise ValueError('boom')\n```")
+        assert not bad.ok
+        # round 3 (corrected) sees x == 1, not the failed round's x == 2
+        r3 = await session.step("```lackpy\ny = x + 10\n```\n\ny={y}")
+        assert r3.ok and "y=11" in r3.clean_doc
+
+    @pytest.mark.asyncio
+    async def test_failed_round_is_not_added_to_rendered(self, context):
+        session = LiterateSession(context)
+        await session.step("Good round.")
+        await session.step("```lackpy\nboom = 1 / 0\n```")   # Left
+        assert "Good round." in session.rendered
+        assert "boom" not in session.rendered
+
+    @pytest.mark.asyncio
+    async def test_continue_requested_surfaces(self, context):
+        session = LiterateSession(context)
+        result = await session.step("```lackpy @continue\n```")
+        assert result.ok and result.continue_requested
+
+
+class TestThinkStripping:
+    def test_strip_closed_block(self):
+        assert strip_think("<think>reasoning here</think>\nHello") == "Hello"
+
+    def test_strip_unclosed_block(self):
+        # model hit the token limit mid-reasoning -> strip to end
+        assert strip_think("Doc start\n<think>partial reason") == "Doc start"
+
+    def test_only_reasoning_strips_to_empty(self):
+        assert strip_think("<think>all thinking, no doc</think>") == ""
+
+    def test_no_think_is_unchanged(self):
+        assert strip_think("plain document") == "plain document"
+
+    @pytest.mark.asyncio
+    async def test_session_strips_think_before_running(self, context):
+        session = LiterateSession(context)
+        result = await session.step(
+            "<think>I should set x to 5</think>\n```lackpy\nx = 5\n```\n\nValue: {x}")
+        assert result.ok
+        assert "Value: 5" in result.clean_doc
+        assert "should set x" not in result.clean_doc     # reasoning never rendered
+
+    @pytest.mark.asyncio
+    async def test_empty_after_strip_is_a_left(self, context):
+        session = LiterateSession(context)
+        result = await session.step("<think>only thinking</think>")
+        assert not result.ok
+        assert "empty" in result.errors[0].lower()
+
+
+class TestGateStillApplies:
+    @pytest.mark.asyncio
+    async def test_ceiling_gate_refuses_in_a_session(self, tmp_path):
+        # The fold runs through _run_document, so the ceiling gate still applies.
+        ctx = ExecutionContext(base_dir=tmp_path, config={"grade_ceiling": Grade(1, 1)})
+        session = LiterateSession(ctx)
+        result = await session.step("```lackpy @write(o.txt)\nhi\n```")
+        assert not result.ok
+        assert "effect ceiling exceeded" in result.errors[0]
+        assert not (tmp_path / "o.txt").exists()


### PR DESCRIPTION
## What
The multi-round `@continue` fold, as an interpreter-package API. Replaces the crude `scripts/literate_agent.py` loop, which built a **fresh kernel each round** and threaded variables as `repr(v)[:200]` **text** — dropping functions entirely (they're filtered out of `metadata["variables"]`).

`LiterateSession` threads **one persistent `LightweightKernel`** across rounds, so functions/imports/objects defined in one round are **live** (real objects) in the next. `step(raw) -> StepResult` is an **Either**:
- **Right**: clean rendered doc (`<think>` stripped at the raw boundary) + advanced state (kernel mutated, journal committed).
- **Left**: errors + the *raw* un-interpreted message for the model to correct — state **not** advanced (file writes rolled back via the journal; kernel name rebindings restored via new `snapshot()/restore()`).

The session is a **pure fold**; the model-call loop is a thin client (`scripts/literate_agent.py`, now feeding `session.scope` *live* state instead of repr text, with a real Left/correction branch).

## Seam
`execute()`'s core is extracted to `_run_document(program, context, kernel)` — `execute()` builds a fresh kernel, `session.step()` reuses the persistent one; both get the same gate + journal. **The refactor landed first as a pure no-op (full suite green) before session semantics were added.**

## Honesty
- Left's "state not advanced" is **rebinding-level**: file writes + name rebindings roll back, but in-place mutations and effects beyond the journal do not — cooperative, the same boundary as the gate (deep copy deliberately avoided: arbitrary/unpicklable live objects, cost).
- `strip_think` handles an **unclosed** `<think>` (truncation) and treats an all-reasoning response as a **Left**, not a silent empty success.

## Tests (+14, suite 980 → 994)
The **DoD**: a function defined in round 1 is *callable* in round 2 — impossible on the old fresh-kernel path (undefined-name + functions dropped). Plus Left-does-not-advance-state, `<think>` stripping (closed/unclosed/empty), continue surfacing, and **the gate still applies in a session**. Live-smoked the thin client (`ollama qwen2.5:1.5b-cpu`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkQezApY9azCwb61ELo86e