### PR TITLE
feat(tools): optional effect metadata on ToolSpec for precise injected-tool grading

### DIFF
--- a/src/lackpy/interpreters/literate/__init__.py
+++ b/src/lackpy/interpreters/literate/__init__.py
@@ -18,7 +18,6 @@ import ast
 import time
 from typing import Any
 
-from ...lang.grader import Grade
 from ..base import (
     ExecutionContext,
     InterpreterExecutionResult,
@@ -32,6 +31,7 @@ from .effects import (
     classify_effects,
     combine,
     exceeds_ceiling,
+    tool_effect_from_spec,
 )
 from .journal import FileJournal
 from .kernel import LightweightKernel
@@ -242,10 +242,12 @@ def _gate_effects_map(context: ExecutionContext) -> dict[str, ToolEffect]:
     read-only ceiling -- the gate's validation surface must match the execution
     surface (``_build_namespace`` injects the same ``context.tools`` callables).
 
-    Injected tools carry no literate-specific path metadata, so ``kind`` is
-    derived from the grade (w>=3 write, w==2 exec, else read); only the grade
-    matters for the ceiling comparison. Conservative defaults (3/3) for tools
-    missing a grade fail closed -- safer to over-refuse than under-refuse.
+    Each injected tool is graded by ``tool_effect_from_spec``: a spec that declares
+    ``effect_kind`` + ``path_arg`` is graded precisely (and an injected write tool
+    with a literal path arg is journalable); a spec that omits them falls back to
+    the grade heuristic (kind from ``grade_w``, no path -> gated but not journaled).
+    Builtins win over injected tools of the same name (the literate ``write_file``
+    in the namespace is what actually runs), so their precise TOML entry stands.
     """
     effects_map = dict(LITERATE_TOOL_EFFECTS)
     resolved = context.tools
@@ -253,10 +255,7 @@ def _gate_effects_map(context: ExecutionContext) -> dict[str, ToolEffect]:
     for name, spec in (specs or {}).items():
         if name in effects_map:
             continue
-        w = getattr(spec, "grade_w", 3)
-        d = getattr(spec, "effects_ceiling", 3)
-        kind = "write" if w >= 3 else "exec" if w == 2 else "read"
-        effects_map[name] = ToolEffect(grade=Grade(w, d), kind=kind)
+        effects_map[name] = tool_effect_from_spec(spec)
     return effects_map
 
 

--- a/src/lackpy/interpreters/literate/effects.py
+++ b/src/lackpy/interpreters/literate/effects.py
@@ -83,6 +83,31 @@ def _load_tool_effects() -> dict[str, ToolEffect]:
 # of truth (tool_effects.toml). Injectable per-call via classify_effects().
 LITERATE_TOOL_EFFECTS: dict[str, ToolEffect] = _load_tool_effects()
 
+
+def tool_effect_from_spec(spec: object) -> ToolEffect:
+    """Derive a :class:`ToolEffect` from a ToolSpec-shaped object (duck-typed).
+
+    The single derivation the ceiling gate uses for profile/toolbox-injected tools.
+    ``effect_kind`` / ``path_arg`` / ``path_index`` on the spec make the tool
+    precise: an injected *write* tool with a declared path arg becomes journalable
+    (its literal target can be rolled back), and a w=3 *exec* tool is not mistaken
+    for a write. When the spec omits ``effect_kind``, ``kind`` falls back to the
+    grade heuristic (w>=3 write, w==2 exec, else read) -- only the grade matters for
+    the ceiling comparison, so an ungraded-kind tool is still gated correctly, just
+    not journaled (no path).
+    """
+    w = getattr(spec, "grade_w", 3)
+    d = getattr(spec, "effects_ceiling", 3)
+    kind = getattr(spec, "effect_kind", None)
+    if kind is None:
+        kind = "write" if w >= 3 else "exec" if w == 2 else "read"
+    return ToolEffect(
+        grade=Grade(w, d),
+        kind=kind,
+        path_arg=getattr(spec, "path_arg", None),
+        path_index=getattr(spec, "path_index", None),
+    )
+
 # Raw effect primitives that defeat name-based classification: code execution
 # (eval/exec/compile/__import__), dynamic attribute access (getattr/setattr/
 # delattr), file/stdin I/O (open/input). Calling any (or importing anything)

--- a/src/lackpy/tools/toolbox.py
+++ b/src/lackpy/tools/toolbox.py
@@ -53,6 +53,14 @@ class ToolSpec:
         docs: Path to a markdown documentation file, relative to the
             provider's package root. Resolved lazily at query time via
             the provider's ``resolve_docs`` method.
+        effect_kind: Optional effect classification (``"read"`` | ``"write"`` |
+            ``"exec"``) for the literate interpreter's effect model. When set, the
+            ceiling gate + write journal grade this tool precisely instead of
+            guessing ``kind`` from ``grade_w`` (which can't tell a w=3 write from a
+            w=3 exec). Ignored by interpreters that don't journal. Default None.
+        path_arg / path_index: For a ``write``/``read`` tool, the name and
+            positional index of the argument carrying a file path. Lets the write
+            journal extract a literal target for rollback. Default None.
     """
 
     name: str
@@ -65,6 +73,10 @@ class ToolSpec:
     effects_ceiling: int = 3
     examples: list[dict] = field(default_factory=list)
     docs: str | None = None
+    # Optional effect metadata for the literate effect model (gate + journal).
+    effect_kind: str | None = None
+    path_arg: str | None = None
+    path_index: int | None = None
 
 
 class Toolbox:

--- a/tests/literate/test_effects.py
+++ b/tests/literate/test_effects.py
@@ -267,3 +267,46 @@ def test_as_grade_rejects_garbage_and_bool():
         as_grade("high")
     with pytest.raises(TypeError):
         as_grade(True)  # bool is an int subclass; reject the ambiguity
+
+
+# --- tool_effect_from_spec: one derivation for injected tools (spec-declared
+#     effect metadata makes an injected write tool precise + journalable) ---
+
+def test_spec_with_effect_metadata_is_precise_and_journalable():
+    from lackpy.interpreters.literate.effects import tool_effect_from_spec
+    from lackpy.tools.toolbox import ToolSpec
+    spec = ToolSpec(name="my_write", provider="python", description="w", args=[],
+                    returns="None", grade_w=3, effects_ceiling=3,
+                    effect_kind="write", path_arg="path", path_index=0)
+    te = tool_effect_from_spec(spec)
+    assert te.kind == "write" and te.path_arg == "path" and te.path_index == 0
+    # a literal-path call to it is journalable (its target lands in writes)
+    eff = classify_effects("my_write('out.txt', 'data')", tool_effects={"my_write": te})
+    assert eff.writes == frozenset({"out.txt"})
+    assert eff.transactional
+
+
+def test_spec_without_effect_kind_falls_back_to_the_grade_heuristic():
+    from lackpy.interpreters.literate.effects import tool_effect_from_spec
+    from lackpy.tools.toolbox import ToolSpec
+    spec = ToolSpec(name="w2", provider="python", description="w", args=[],
+                    returns="None", grade_w=3, effects_ceiling=3)  # no effect metadata
+    te = tool_effect_from_spec(spec)
+    assert te.kind == "write"          # heuristic from grade_w
+    assert te.path_arg is None
+    # no declared path -> the heuristic can't journal it (dynamic)
+    eff = classify_effects("w2('out.txt', 'data')", tool_effects={"w2": te})
+    assert eff.writes == frozenset()
+    assert eff.dynamic_paths and not eff.transactional
+
+
+def test_w3_exec_spec_is_not_mistaken_for_a_write():
+    # The heuristic maps w>=3 -> write; an explicit effect_kind="exec" fixes it.
+    from lackpy.interpreters.literate.effects import tool_effect_from_spec
+    from lackpy.tools.toolbox import ToolSpec
+    spec = ToolSpec(name="sh", provider="python", description="x", args=[],
+                    returns="None", grade_w=3, effects_ceiling=3, effect_kind="exec")
+    te = tool_effect_from_spec(spec)
+    assert te.kind == "exec"
+    eff = classify_effects("sh('rm -rf /tmp/x')", tool_effects={"sh": te})
+    assert eff.exec_calls == frozenset({"sh"}) and eff.needs_sandbox

--- a/tests/literate/test_interpreter.py
+++ b/tests/literate/test_interpreter.py
@@ -463,3 +463,43 @@ class TestTransactionalWrites:
         result = await interpreter.execute(doc, ctx)
         assert not result.success
         assert (tmp_path / "hello.txt").read_text() == "Hello World\n"   # restored
+
+
+class TestInjectedToolJournaling:
+    """An injected (profile) write-tool with declared effect metadata is journaled
+    (rolled back on failure); without it the heuristic can't extract the literal
+    path, so it is not -- the targeted precision win over the grade heuristic.
+    """
+
+    @staticmethod
+    def _writer_tools(tmp_path, *, precise):
+        def mywrite(path, content):
+            (tmp_path / path).write_text(content)
+
+        meta = dict(effect_kind="write", path_arg="path", path_index=0) if precise else {}
+        spec = ToolSpec(name="mywrite", provider="python", description="w",
+                        args=[], returns="None", grade_w=3, effects_ceiling=3, **meta)
+        return ResolvedTools(tools={"mywrite": spec}, callables={"mywrite": mywrite},
+                             grade=Grade(3, 3), description="w")
+
+    DOC = '```lackpy\nmywrite("out.txt", "data")\n```\n\n```lackpy\nraise ValueError("boom")\n```'
+
+    @pytest.mark.asyncio
+    async def test_injected_write_with_path_metadata_is_rolled_back(self, interpreter, tmp_path):
+        resolved = self._writer_tools(tmp_path, precise=True)
+        ctx = ExecutionContext(base_dir=tmp_path, tools=resolved,
+                               config={"grade_ceiling": Grade(3, 3)})
+        result = await interpreter.execute(self.DOC, ctx)
+        assert not result.success
+        assert not (tmp_path / "out.txt").exists()      # journaled -> rolled back
+
+    @pytest.mark.asyncio
+    async def test_injected_write_without_metadata_is_not_rolled_back(self, interpreter, tmp_path):
+        # Heuristic fallback: kind=write but no declared path -> dynamic -> the
+        # journal never snapshots it, so the failed doc's write persists.
+        resolved = self._writer_tools(tmp_path, precise=False)
+        ctx = ExecutionContext(base_dir=tmp_path, tools=resolved,
+                               config={"grade_ceiling": Grade(3, 3)})
+        result = await interpreter.execute(self.DOC, ctx)
+        assert not result.success
+        assert (tmp_path / "out.txt").read_text() == "data"   # NOT rolled back


### PR DESCRIPTION
## What
Targeted unification of the ceiling gate's two grade sources. Adds optional `effect_kind` / `path_arg` / `path_index` to `ToolSpec` (default `None`, backward-compatible) and **one derivation** — `effects.tool_effect_from_spec(spec)` — that the gate uses for profile/toolbox-injected tools, demoting the old inline `grade_w→kind` heuristic to a **fallback**.

## The win
An injected write-tool that declares `effect_kind="write"` + `path_arg` is now **journalable** — its literal target lands in the doc's `writes` and rolls back on failure. The heuristic couldn't do this (no path → dynamic → never snapshotted). A w=3 *exec* tool with `effect_kind="exec"` is also no longer mistaken for a write. Specs that omit the metadata behave **exactly as before**.

## Scope (deliberately bounded)
Per the advisor's scope review, the **literate builtins are left alone** — their spec-shaped `tool_effects.toml` already grades them precisely and correctly wins over injected tools of the same name (the namespace's `write_file` is what runs). Re-plumbing them through spec conversion would be churn for zero behavior change. This slice only closes the injected-tool precision gap; it does **not** put the full effect model on every path.

## Tests (+5, suite 994 → 999)
`tool_effect_from_spec` precise / fallback / exec at the classifier level, plus the **discriminating end-to-end**: an injected write-tool **with** path metadata is rolled back on a failed doc, **without** it it persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GkQezApY9azCwb61ELo86e