### PR TITLE
Harden AST validation against dunder-traversal attribute access

### DIFF
--- a/packages/lackpy-lang/src/lackpy/lang/grammar.py
+++ b/packages/lackpy-lang/src/lackpy/lang/grammar.py
@@ -57,6 +57,25 @@ FORBIDDEN_NAMES: frozenset[str] = frozenset({
     "os", "sys", "pathlib", "subprocess", "shutil",
 })
 
+# Attribute names that are always denied, even without an underscore prefix.
+# The primary attribute guard is a *prefix* rule (reject any attribute whose name
+# starts with "_"), which covers the whole dunder-traversal escape family
+# (__class__/__bases__/__subclasses__/__globals__/__mro__/__init__/…) and the
+# single-underscore private-attribute gadgets (e.g. ``()._module``).
+#
+# These names have NO leading underscore, so the prefix rule would miss them. They
+# are frame/generator/coroutine/traceback internals that expose a real namespace
+# (``f_globals``/``f_builtins``). They are believed UNREACHABLE in the current
+# subset (no GeneratorExp / Try / Raise / sys => no frame, generator, or traceback
+# object can be constructed), but they are denied explicitly as defense-in-depth
+# so a future grammar addition cannot silently re-open the route.
+DENIED_ATTRIBUTES: frozenset[str] = frozenset({
+    "f_globals", "f_builtins", "f_locals", "f_code", "f_back",
+    "gi_frame", "gi_code", "cr_frame", "cr_code",
+    "ag_frame", "ag_code", "tb_frame", "tb_next",
+    "func_globals", "func_code",
+})
+
 ALLOWED_BUILTINS: frozenset[str] = frozenset({
     "len", "sorted", "reversed", "enumerate", "zip", "range",
     "min", "max", "sum", "any", "all", "abs", "round",

--- a/packages/lackpy-lang/src/lackpy/lang/validator.py
+++ b/packages/lackpy-lang/src/lackpy/lang/validator.py
@@ -134,7 +134,11 @@ def validate(
                 )
         elif isinstance(func, ast.Attribute):
             # Method call on a value; Step 3.5 already vetted the attribute name.
-            calls.append(func.attr)
+            # Intentionally NOT recorded in ``calls``: that list drives the
+            # kibitzer planned-tool-call pre-check, which must see only named
+            # (Name-target) tool/builtin calls — recording method names like
+            # ``split``/``items`` there would surface them as ungranted "tools".
+            pass
         else:
             # Call of a subscript / call result / other expression — default-deny.
             errors.append(

--- a/packages/lackpy-lang/src/lackpy/lang/validator.py
+++ b/packages/lackpy-lang/src/lackpy/lang/validator.py
@@ -5,7 +5,12 @@ from __future__ import annotations
 import ast
 from dataclasses import dataclass, field
 
-from .grammar import ALLOWED_NODES, FORBIDDEN_NAMES, ALLOWED_BUILTINS
+from .grammar import (
+    ALLOWED_NODES,
+    FORBIDDEN_NAMES,
+    ALLOWED_BUILTINS,
+    DENIED_ATTRIBUTES,
+)
 
 
 @dataclass
@@ -83,16 +88,59 @@ def validate(
         if isinstance(node, ast.Name) and node.id in FORBIDDEN_NAMES:
             errors.append(f"Forbidden name: '{node.id}' at line {node.lineno}")
 
-    # Step 4: Namespace check — reject calls to unknown functions
+    # Step 3.5: Attribute check — the sandbox boundary (GHSA-hpcj-3c97-43jm).
+    #
+    # ast.Attribute is allowed (data objects legitimately expose methods like
+    # ``.split``/``.items``/``.get``), but attribute *names* are restricted so an
+    # attribute chain cannot walk from a benign value to a type or module object:
+    #   - any name starting with "_" is denied — this covers the entire dunder
+    #     traversal escape family (``__class__``/``__bases__``/``__subclasses__``/
+    #     ``__globals__``/``__mro__``/``__init__``/``__getattribute__``/…) as well
+    #     as single-underscore private gadgets (e.g. ``()._module``).
+    #   - a small set of non-underscore frame/generator internals (``f_globals``,
+    #     ``gi_frame``, …) is denied explicitly (see DENIED_ATTRIBUTES).
+    # This is an allow-by-shape / deny-by-name rule: it does not enumerate every
+    # safe attribute (that set is open-ended for arbitrary data), so it is a
+    # denylist on the dangerous shape. The known-complete escape surface in this
+    # subset is underscore-prefixed names; the explicit frame set covers the only
+    # non-underscore internals that expose a namespace.
     for node in ast.walk(tree):
-        if isinstance(node, ast.Call) and isinstance(node.func, ast.Name):
-            name = node.func.id
+        if isinstance(node, ast.Attribute):
+            attr = node.attr
+            if attr.startswith("_") or attr in DENIED_ATTRIBUTES:
+                errors.append(
+                    f"Forbidden attribute access: '.{attr}' at line {node.lineno} "
+                    f"(private/dunder/internal attribute access is not permitted)"
+                )
+
+    # Step 4: Namespace check — reject calls to unknown / unresolvable functions.
+    #
+    # Every ast.Call is inspected (not only ``func is ast.Name``): a call whose
+    # target is an attribute (``data.split(...)``) is permitted only because the
+    # attribute name already passed Step 3.5; a call whose target is a Subscript
+    # or another Call/expression is default-denied here — those exotic call forms
+    # are not part of the intended subset and were an unchecked bypass before.
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
+        func = node.func
+        if isinstance(func, ast.Name):
+            name = func.id
             calls.append(name)
             if name not in all_allowed_calls and name not in FORBIDDEN_NAMES:
                 errors.append(
                     f"Unknown function: '{name}' at line {node.lineno} "
                     f"(not in kit or builtins)"
                 )
+        elif isinstance(func, ast.Attribute):
+            # Method call on a value; Step 3.5 already vetted the attribute name.
+            calls.append(func.attr)
+        else:
+            # Call of a subscript / call result / other expression — default-deny.
+            errors.append(
+                f"Unsupported call target ({type(func).__name__}) at line "
+                f"{node.lineno}: only named functions and method calls are allowed"
+            )
 
     # Step 5: For-loop check — must iterate over call result or variable
     for node in ast.walk(tree):

--- a/src/lackpy/service.py
+++ b/src/lackpy/service.py
@@ -814,11 +814,15 @@ class LackpyService:
                     }
 
         # Dispatch by the profile's execution axis (literate vs restricted Python),
-        # the same seam run_program uses. allowed=None preserves delegate's prior
-        # behaviour of not re-validating the generated program before _execute; the
+        # the same seam run_program uses. Defense-in-depth (GHSA-hpcj-3c97-43jm):
+        # re-validate the generated program against the same allowed names at the
+        # execution boundary, rather than trusting the generation-time gate alone.
+        # The restricted-Python path parses the identical source deterministically,
+        # so this closes the validate/execute gap without a differential; the
         # literate path validates internally by parsing.
         exec_result = await self._execute_program(
             gen_result.program, rp, resolved, param_values,
+            allowed=set(resolved.tools.keys()) | param_names,
             kibitzer_session=self._kibitzer,
         )
 

--- a/tests/lang/test_grammar.py
+++ b/tests/lang/test_grammar.py
@@ -2,7 +2,13 @@
 
 import ast
 
-from lackpy.lang.grammar import ALLOWED_NODES, FORBIDDEN_NODES, FORBIDDEN_NAMES, ALLOWED_BUILTINS
+from lackpy.lang.grammar import (
+    ALLOWED_NODES,
+    FORBIDDEN_NODES,
+    FORBIDDEN_NAMES,
+    ALLOWED_BUILTINS,
+    DENIED_ATTRIBUTES,
+)
 
 
 def test_allowed_and_forbidden_are_disjoint():
@@ -52,3 +58,11 @@ def test_key_builtins_present():
 
 def test_sort_by_in_builtins():
     assert "sort_by" in ALLOWED_BUILTINS
+
+
+def test_denied_attributes_cover_non_underscore_frame_internals():
+    # These have no leading underscore, so the attribute-prefix rule would miss
+    # them; the explicit deny set is the only thing that stops them.
+    for attr in ("f_globals", "f_builtins", "gi_frame", "cr_frame", "tb_frame"):
+        assert attr in DENIED_ATTRIBUTES
+        assert not attr.startswith("_")

--- a/tests/lang/test_sandbox_escape.py
+++ b/tests/lang/test_sandbox_escape.py
@@ -73,6 +73,21 @@ class TestDunderTraversalEscapes:
         result = validate(prog)
         assert _attr_rejected(result), result.errors
 
+    def test_rejects_verbatim_reported_chain(self):
+        # The exact structure of the reported escape, with a BENIGN marker call
+        # target (never executed — validation rejects it first). Pins both the
+        # dunder-attribute guard AND the subscript-call default-deny in one test:
+        # the final ``g['marker'](...)`` has func=Subscript.
+        prog = (
+            "subs = ().__class__.__bases__[0].__subclasses__()\n"
+            "g = [c for c in subs if c.__name__ == 'marker'][0].__init__.__globals__\n"
+            "g['marker']('SENTINEL_NOT_EXECUTED')\n"
+        )
+        result = validate(prog)
+        assert not result.valid, result.errors
+        # Rejected for the attribute walk (dunder access), not merely the call form.
+        assert _attr_rejected(result), result.errors
+
 
 class TestPrivateAttributeEscapes:
     """Single-underscore private attributes: broader than the advisory's literal

--- a/tests/lang/test_sandbox_escape.py
+++ b/tests/lang/test_sandbox_escape.py
@@ -1,0 +1,163 @@
+"""Adversarial tests for the AST-whitelist sandbox boundary (GHSA-hpcj-3c97-43jm).
+
+These assert the validator REJECTS the dunder/private attribute-traversal escape
+family *before execution*. No test executes an escape: the sentinel is a benign
+marker object; we only assert ``validate(...).valid is False`` and that the
+rejection reason names the attribute, so a green cannot come from an unrelated
+rejection.
+"""
+
+import pytest
+
+from lackpy.lang.validator import validate
+
+
+def _attr_rejected(result) -> bool:
+    """A rejection attributable to the attribute-access guard specifically."""
+    return not result.valid and any(
+        "attribute" in e.lower() for e in result.errors
+    )
+
+
+class TestDunderTraversalEscapes:
+    """The confirmed escape family: reach type/module objects via dunder walk."""
+
+    def test_rejects_confirmed_subclasses_escape(self):
+        # ().__class__.__bases__[0].__subclasses__() — the reported chain.
+        prog = "subs = ().__class__.__bases__[0].__subclasses__()"
+        result = validate(prog)
+        assert _attr_rejected(result), result.errors
+
+    def test_rejects_globals_walk(self):
+        # …__init__.__globals__ — the step that reaches the real module namespace.
+        prog = (
+            "subs = ().__class__.__bases__[0].__subclasses__()\n"
+            "g = subs[0].__init__.__globals__\n"
+        )
+        result = validate(prog)
+        assert _attr_rejected(result), result.errors
+
+    def test_rejects_dunder_via_comprehension(self):
+        prog = (
+            "subs = ().__class__.__bases__[0].__subclasses__()\n"
+            "picked = [c for c in subs if c.__name__ == 'x']\n"
+        )
+        result = validate(prog)
+        assert _attr_rejected(result), result.errors
+
+    def test_rejects_dunder_via_subscript_chain(self):
+        prog = "x = ().__class__.__mro__[-1].__subclasses__()"
+        result = validate(prog)
+        assert _attr_rejected(result), result.errors
+
+    def test_rejects_getattribute_attr(self):
+        # __getattribute__ as an attribute (distinct from the string-const path).
+        prog = "x = ().__getattribute__"
+        result = validate(prog)
+        assert _attr_rejected(result), result.errors
+
+    def test_rejects_globals_on_whitelisted_builtin(self):
+        # A whitelisted-looking Name (allowed builtin) walked to __globals__.
+        prog = "g = sorted.__globals__"
+        result = validate(prog)
+        assert _attr_rejected(result), result.errors
+
+    def test_rejects_dunder_inside_fstring(self):
+        # FormattedValue carrying a dunder attribute-access.
+        prog = "x = f'{().__class__}'"
+        result = validate(prog)
+        assert _attr_rejected(result), result.errors
+
+    def test_rejects_bare_dunder_attribute(self):
+        prog = "x = ().__class__"
+        result = validate(prog)
+        assert _attr_rejected(result), result.errors
+
+
+class TestPrivateAttributeEscapes:
+    """Single-underscore private attributes: broader than the advisory's literal
+    ``__`` wording, closing the ``()._module``-style gadget it references."""
+
+    def test_rejects_single_underscore_attribute(self):
+        prog = "x = some_obj._module"
+        result = validate(prog, allowed_names={"some_obj"})
+        assert _attr_rejected(result), result.errors
+
+    def test_rejects_private_attribute_call(self):
+        prog = "x = some_obj._private_method()"
+        result = validate(prog, allowed_names={"some_obj"})
+        assert _attr_rejected(result), result.errors
+
+
+class TestFrameAttributeEscapes:
+    """Frame/generator/traceback attributes have no leading underscore, so an
+    underscore-only ban would miss them. They are currently UNREACHABLE in the
+    subset (no GeneratorExp / Try / Raise / sys), but we deny them explicitly as
+    belt-and-suspenders. This is the named residual of a denylist approach."""
+
+    @pytest.mark.parametrize(
+        "attr",
+        ["f_globals", "f_builtins", "f_locals", "gi_frame", "cr_frame", "tb_frame"],
+    )
+    def test_rejects_frame_attribute(self, attr):
+        prog = f"x = some_obj.{attr}"
+        result = validate(prog, allowed_names={"some_obj"})
+        assert not result.valid, result.errors
+
+
+class TestExoticCallForms:
+    """Step 4 default-denies calls whose target is not a Name or method
+    attribute — the previously-unchecked bypass where ``func`` is a Subscript or
+    a Call result."""
+
+    def test_rejects_call_of_subscript(self):
+        result = validate("x = funcs[0]()", allowed_names={"funcs"})
+        assert not result.valid, result.errors
+        assert any("call target" in e.lower() for e in result.errors), result.errors
+
+    def test_rejects_call_of_call_result(self):
+        result = validate("x = get()()", allowed_names={"get"})
+        assert not result.valid, result.errors
+        assert any("call target" in e.lower() for e in result.errors), result.errors
+
+
+class TestDunderRegardlessOfValueShape:
+    """The attribute guard must fire no matter what expression the dunder is
+    accessed *on* — a Tuple, a Subscript, a method-call result, etc."""
+
+    def test_rejects_dunder_on_subscript_of_call(self):
+        result = validate("x = data.items()[0].__class__", allowed_names={"data"})
+        assert _attr_rejected(result), result.errors
+
+    def test_rejects_dunder_on_method_chain(self):
+        result = validate("s = get()\nx = s.encode().__class__", allowed_names={"get"})
+        assert _attr_rejected(result), result.errors
+
+    def test_rejects_globals_on_subscript(self):
+        result = validate("x = lst[0].__globals__", allowed_names={"lst"})
+        assert _attr_rejected(result), result.errors
+
+
+class TestNoOverBlocking:
+    """Legitimate attribute access on data objects must still validate — the
+    guard keys on underscore prefixes / a small deny set, not all attributes."""
+
+    def test_allows_str_split(self):
+        prog = "data = read_file('f.txt')\nlines = data.split('\\n')"
+        result = validate(prog, allowed_names={"read_file"})
+        assert result.valid, result.errors
+
+    def test_allows_dict_methods(self):
+        prog = "d = load()\nks = d.keys()\nvs = d.values()\nits = d.items()"
+        result = validate(prog, allowed_names={"load"})
+        assert result.valid, result.errors
+
+    def test_allows_str_methods(self):
+        prog = "s = get()\nout = s.strip().upper().replace('a', 'b')"
+        result = validate(prog, allowed_names={"get"})
+        assert result.valid, result.errors
+
+    def test_allows_get_with_default(self):
+        prog = "d = load()\nv = d.get('key')"
+        result = validate(prog, allowed_names={"load"})
+        assert result.valid, result.errors


### PR DESCRIPTION
## Summary

Tightens the restricted-Python language subset so a generated program cannot
walk an attribute chain from a benign value to type/module objects and reach
the surrounding module namespace. The previous validator allowed
`ast.Attribute` with no restriction on attribute names, and only inspected
calls whose `func` was a bare `Name`.

Security hardening — references **GHSA-hpcj-3c97-43jm** (draft advisory; to be
published at release). Deliberately does not spell out the mechanism here.

## Changes

- **Attribute-name guard** (new validator step): reject any attribute whose
  name starts with `_` — this covers the dunder family
  (`__class__`/`__bases__`/`__subclasses__`/`__globals__`/`__mro__`/`__init__`/…)
  and single-underscore private gadgets — plus an explicit deny set of
  non-underscore frame/generator internals (`f_globals`, `gi_frame`, …) that a
  prefix rule would miss.
- **Full call coverage**: every `ast.Call` is inspected, not only
  `func is ast.Name`. Method calls are permitted via the attribute guard; calls
  whose target is a subscript or another call/expression are default-denied
  (these were an unchecked bypass).
- **Defense-in-depth at the exec boundary**: the `delegate` path now
  re-validates the generated program against the same allowed names before
  execution, instead of trusting the generation-time gate alone.

## Testing

Reproduce-first: new `tests/lang/test_sandbox_escape.py` fails on the current
code (the escape family validates as benign) and passes after the fix (the
validator rejects it before execution). No test executes an escape — the
assertions are on `validate(...).valid` and on the specific rejection reason.

- Escape family (dunder traversal, `__globals__` walk, via comprehension /
  subscript / f-string / `__getattribute__`, dunder on subscript-of-call and
  method-chain results) → **rejected**.
- Exotic call forms (call of a subscript, call of a call result) → **rejected**.
- Frame/generator internals (`f_globals`, `gi_frame`, `cr_frame`, …) →
  **rejected** (belt-and-suspenders; currently unreachable in the subset).
- Over-block guards: legitimate `.split`/`.items`/`.keys`/`.get`/`.strip`
  method and dict access still **validate**.

Full `tests/` suite: **1019 passed, 12 skipped**.

## Calibration / residual risk

- **Denylist, not a pure allowlist.** The attribute guard denies by shape
  (underscore-prefixed names + a fixed frame-internal set) rather than
  enumerating every safe attribute, because the safe-attribute set is
  open-ended for arbitrary data objects. The known escape surface in this
  subset is underscore-prefixed names; the explicit frame set is the only
  non-underscore route to a namespace, and it is believed unreachable here
  (no generator/traceback/frame objects are constructible in the subset). A
  future grammar addition (e.g. generator expressions) would need to re-check
  this — hence the explicit deny set and its test.
- **Validate/execute AST binding**: validator and runner still parse the same
  source string independently rather than sharing one AST object. Parsing is
  deterministic over identical source and the exec-boundary re-validation now
  closes the delegate skip, so there is no differential on the reviewed paths;
  a single-AST binding remains a follow-up hardening, not a fix in this PR.
- **Out of scope (separate execution axis)**: the literate `LightweightKernel`
  runs cells with full `__builtins__` under an effect-grade ceiling model, not
  the AST allowlist. That is a distinct execution surface with its own gate and
  is not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LjVKQED5RRjQzArQZA8X4n